### PR TITLE
Realm member permissions

### DIFF
--- a/Types.ts
+++ b/Types.ts
@@ -184,6 +184,7 @@ export interface DbBoardMetadata {
   permissions: string[];
   logged_out_restrictions: string[];
   logged_in_base_restrictions: string[];
+  realm_string_id?: string;
 }
 
 export interface QueryTagsType {

--- a/db/init/020_roles_and_permissions.sql
+++ b/db/init/020_roles_and_permissions.sql
@@ -15,7 +15,10 @@ CREATE TYPE role_permissions_type AS ENUM (
     'edit_whisper_tags',
     'edit_index_tags',
     'edit_default_view',
-    'create_realm_invite'
+    'create_realm_invite',
+    'post_on_realm',
+    'comment_on_realm',
+    'access_member_only_content_on_realm'
 );
 
 CREATE TABLE IF NOT EXISTS roles

--- a/db/init/020_roles_and_permissions.sql
+++ b/db/init/020_roles_and_permissions.sql
@@ -18,7 +18,8 @@ CREATE TYPE role_permissions_type AS ENUM (
     'create_realm_invite',
     'post_on_realm',
     'comment_on_realm',
-    'access_member_only_content_on_realm'
+    'create_thread_on_realm',
+    'access_locked_boards_on_realm'
 );
 
 CREATE TABLE IF NOT EXISTS roles

--- a/db/test_db_init/070_roles_insert.sql
+++ b/db/test_db_init/070_roles_insert.sql
@@ -33,7 +33,7 @@ VALUES
      (SELECT id FROM roles WHERE name = 'The Owner')),
     ((SELECT id FROM realms WHERE slug = 'uwu'),
      (SELECT id FROM users WHERE username = 'bobatan'), 
-     (SELECT id FROM roles WHERE name = 'The Owner')),
+     (SELECT id FROM roles WHERE name = 'The Memester')),
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'),
      (SELECT id FROM users WHERE username = 'bobatan'),
      (SELECT id FROM roles WHERE name = 'GoreMaster5000')),

--- a/handlers/permissions.ts
+++ b/handlers/permissions.ts
@@ -277,7 +277,7 @@ export const withRealmPermissions = async (
 
     const currentRealmPermissions = await getUserPermissionsForRealm({
       firebaseId: req.currentUser.uid,
-      realmId: req.currentRealmIds.string_id,
+      realmStringId: req.currentRealmIds.string_id,
     });
 
     if (!currentRealmPermissions) {

--- a/handlers/permissions.ts
+++ b/handlers/permissions.ts
@@ -306,17 +306,13 @@ export const withRealmPermissions = async (
         "Realm permissions can only be fetched on a route that includes a realm id."
       );
     }
-    if (!req.currentUser) {
-      next();
-      return;
-    }
-    if (req.currentRealmPermissions) {
+    if (!!req.currentRealmPermissions) {
       next();
       return;
     }
 
     const currentRealmPermissions = await getUserPermissionsForRealm({
-      firebaseId: req.currentUser.uid,
+      firebaseId: req.currentUser?.uid,
       realmStringId: req.currentRealmIds.string_id,
     });
 

--- a/handlers/permissions.ts
+++ b/handlers/permissions.ts
@@ -201,7 +201,7 @@ export const ensureBoardAccess = async (
       }
       if (
         !req.currentRealmPermissions.includes(
-          RealmPermissions.accessMemberOnlyContentOnRealm
+          RealmPermissions.accessLockedBoardsOnRealm
         ) &&
         req.currentBoardRestrictions.loggedOutRestrictions.includes(
           BoardRestrictions.LOCK_ACCESS

--- a/server/boards/routes.ts
+++ b/server/boards/routes.ts
@@ -167,7 +167,7 @@ router.post(
   "/:board_id",
   ensureLoggedIn,
   ensureBoardAccess,
-  ensureRealmPermission(RealmPermissions.postOnRealm),
+  ensureRealmPermission(RealmPermissions.createThreadOnRealm),
   //TODO: ensureBoardPermission(BoardPermissions.createThread),
   async (req, res, next) => {
     const { board_id: boardId } = req.params;
@@ -316,7 +316,7 @@ router.patch(
       firebaseId: req.currentUser?.uid,
       boardId,
       hasBoardAccess: req.currentRealmPermissions.includes(
-        RealmPermissions.accessMemberOnlyContentOnRealm
+        RealmPermissions.accessLockedBoardsOnRealm
       ),
     });
     res.status(200).json(boardMetadata);

--- a/server/boards/routes.ts
+++ b/server/boards/routes.ts
@@ -106,7 +106,7 @@ router.get("/:board_id", ensureBoardAccess, async (req, res) => {
   const boardMetadata = await getBoardMetadataByUuid({
     firebaseId: req.currentUser?.uid,
     boardId,
-    hasBoardAccess: true,
+    hasBoardAccess: req.currentUser ? true : false,
   });
 
   log(`Returning data for board ${boardId} for user ${req.currentUser?.uid}.`);
@@ -292,8 +292,8 @@ router.post(
 router.patch(
   "/:board_id/",
   ensureLoggedIn,
-  withRealmPermissions,
   ensureBoardPermission(BoardPermissions.editMetadata),
+  withRealmPermissions,
   async (req, res) => {
     const { board_id: boardId } = req.params;
     const { descriptions, accentColor, tagline } = req.body;

--- a/server/boards/routes.ts
+++ b/server/boards/routes.ts
@@ -436,7 +436,7 @@ router.post(
     }
 
     await cache().hdel(CacheKeys.BOARD, boardId);
-    await cache().hdel(CacheKeys.USER, req.currentUser.uid);
+    await cache().hdel(CacheKeys.USER_PINS, req.currentUser.uid);
 
     info(`Muted board: ${boardId} for user ${req.currentUser.uid}.`);
     res.sendStatus(204);
@@ -493,7 +493,7 @@ router.delete(
     }
 
     await cache().hdel(CacheKeys.BOARD, boardId);
-    await cache().hdel(CacheKeys.USER, req.currentUser.uid);
+    await cache().hdel(CacheKeys.USER_PINS, req.currentUser.uid);
 
     info(`Unmuted board: ${boardId} for user ${req.currentUser.uid}.`);
     res.sendStatus(204);
@@ -551,7 +551,7 @@ router.post(
     }
 
     await cache().hdel(CacheKeys.BOARD, boardId);
-    await cache().hdel(CacheKeys.USER, req.currentUser.uid);
+    await cache().hdel(CacheKeys.USER_PINS, req.currentUser.uid);
 
     info(`Pinned board: ${boardId} for user ${req.currentUser.uid}.`);
     res.sendStatus(204);
@@ -611,7 +611,7 @@ router.delete(
     }
 
     await cache().hdel(CacheKeys.BOARD, boardId);
-    await cache().hdel(CacheKeys.USER, req.currentUser.uid);
+    await cache().hdel(CacheKeys.USER_PINS, req.currentUser.uid);
 
     info(`Unpinned board: ${boardId} for user ${req.currentUser?.uid}.`);
     res.sendStatus(204);

--- a/server/boards/sql/board-by-uuid.sql
+++ b/server/boards/sql/board-by-uuid.sql
@@ -9,6 +9,7 @@ SELECT
     boards.tagline,
     boards.avatar_reference_id as avatar_url,
     boards.settings,
+    realms.string_id as realm_string_id,
     COALESCE(json_agg(DISTINCT jsonb_build_object(
         'id', bds.string_id,
         'index', bds.index, 
@@ -79,5 +80,7 @@ FROM boards
         ON boards.id = br.board_id
     LEFT JOIN logged_in_user
         ON 1=1
+    LEFT JOIN realms
+        ON boards.parent_realm_id = realms.id
 WHERE boards.string_id=${board_uuid}
 GROUP BY boards.id, umb.user_id, opb.index, br.logged_out_restrictions, br.logged_in_base_restrictions, logged_in_user.id

--- a/server/boards/sql/board-by-uuid.sql
+++ b/server/boards/sql/board-by-uuid.sql
@@ -83,4 +83,4 @@ FROM boards
     LEFT JOIN realms
         ON boards.parent_realm_id = realms.id
 WHERE boards.string_id=${board_uuid}
-GROUP BY boards.id, umb.user_id, opb.index, br.logged_out_restrictions, br.logged_in_base_restrictions, logged_in_user.id
+GROUP BY boards.id, realms.string_id, umb.user_id, opb.index, br.logged_out_restrictions, br.logged_in_base_restrictions, logged_in_user.id

--- a/server/boards/sql/board-by-uuid.sql
+++ b/server/boards/sql/board-by-uuid.sql
@@ -54,7 +54,7 @@ FROM boards
     LEFT JOIN board_user_roles bur 
         ON boards.id = bur.board_id AND bur.user_id = (SELECT id FROM logged_in_user LIMIT 1)
     LEFT JOIN realm_user_roles rur
-        ON rur.user_id = (SELECT id FROM logged_in_user LIMIT 1)
+        ON boards.parent_realm_id = rur.realm_id AND rur.user_id = (SELECT id FROM logged_in_user LIMIT 1)
     LEFT JOIN realm_accessories
         ON TRUE 
     LEFT JOIN accessories

--- a/server/boards/tests/by-uuid.test.ts
+++ b/server/boards/tests/by-uuid.test.ts
@@ -2,6 +2,7 @@ import { BOBATAN_USER_ID } from "test/data/auth";
 import { DbBoardMetadata } from "Types";
 import { GORE_BOARD_ID } from "test/data/boards";
 import { getBoardByUuid } from "../queries";
+import { TWISTED_MINDS_REALM_STRING_ID } from "test/data/realms";
 
 const GORE_BOARD_LOGGED_OUT: DbBoardMetadata = {
   settings: {
@@ -29,6 +30,7 @@ const GORE_BOARD_LOGGED_OUT: DbBoardMetadata = {
   string_id: "c6d3d10e-8e49-4d73-b28a-9d652b41beec",
   tagline: "Blood! Blood! Blood!",
   avatar_url: "gore.png",
+  realm_string_id: TWISTED_MINDS_REALM_STRING_ID,
   // TODO: do we want to surface accessories for
   // non-logged in users?
   accessories: [
@@ -77,6 +79,7 @@ const GORE_BOARD_LOGGED_IN: DbBoardMetadata = {
   string_id: "c6d3d10e-8e49-4d73-b28a-9d652b41beec",
   tagline: "Blood! Blood! Blood!",
   avatar_url: "gore.png",
+  realm_string_id: TWISTED_MINDS_REALM_STRING_ID,
   muted: false,
   permissions: [
     "edit_board_details",

--- a/server/boards/tests/routes/board-by-uuid.test.ts
+++ b/server/boards/tests/routes/board-by-uuid.test.ts
@@ -1,8 +1,12 @@
+import { BOBATAN_USER_ID, JERSEY_DEVIL_USER_ID } from "test/data/auth";
 import { CacheKeys, cache } from "server/cache";
-import { GORE_BOARD_ID, GORE_BOARD_METADATA } from "test/data/boards";
+import {
+  GORE_BOARD_ID,
+  GORE_BOARD_METADATA,
+  RESTRICTED_BOARD_ID,
+} from "test/data/boards";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
-import { BOBATAN_USER_ID } from "test/data/auth";
 import { BoardMetadata } from "types/rest/boards";
 import debug from "debug";
 import { mocked } from "ts-jest/utils";
@@ -58,5 +62,24 @@ describe("Tests boards REST API", () => {
     );
     expect(res.status).toBe(200);
     expect(res.body).toEqual(modifiedData);
+  });
+
+  test("Correctly does not return board data for restricted board if user not a realm member", async () => {
+    setLoggedInUser(JERSEY_DEVIL_USER_ID);
+    const res = await request(server.app).get(`/${RESTRICTED_BOARD_ID}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      message: "User does not have required permission to access board.",
+    });
+  });
+
+  test("Correctly does not return board data for restricted board if not logged in", async () => {
+    const res = await request(server.app).get(`/${RESTRICTED_BOARD_ID}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      message: "User must be authenticated to access board.",
+    });
   });
 });

--- a/server/boards/tests/routes/create-thread.test.ts
+++ b/server/boards/tests/routes/create-thread.test.ts
@@ -3,6 +3,7 @@ import * as uuid from "uuid";
 import {
   BOBATAN_USER_ID,
   GORE_MASTER_IDENTITY_ID,
+  JERSEY_DEVIL_USER_ID,
   SEXY_DADDY_USER_ID,
 } from "test/data/auth";
 import { CREATE_GORE_THREAD_RESPONSE, NULL_ID } from "test/data/threads";
@@ -206,6 +207,19 @@ describe("Tests threads REST API - create", () => {
         });
 
       expect(res.status).toBe(403);
+    });
+  });
+
+  test("Does not create thread when user not a member of realm", async () => {
+    await wrapWithTransaction(async () => {
+      setLoggedInUser(JERSEY_DEVIL_USER_ID);
+      const res = await request(server.app)
+        .post(`/${GORE_BOARD_ID}`)
+        .send(CREATE_GORE_THREAD_BASE_REQUEST);
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({
+        message: "User does not have required permissions for realm operation.",
+      });
     });
   });
 });

--- a/server/boards/tests/routes/mute-board.test.ts
+++ b/server/boards/tests/routes/mute-board.test.ts
@@ -58,9 +58,9 @@ describe("Tests mute boards REST API", () => {
       expect(res.status).toBe(204);
       // Ensure that the user cache was cleared since that contains the muted boards.
       // TODO: this is an implementation details and it should be tested by checking the
-      // users/@me endpoint.
+      // users/@me/pins/realm/:realm_id endpoint.
       expect(cache().hdel).toBeCalledTimes(2);
-      expect(cache().hdel).toBeCalledWith(CacheKeys.USER, BOBATAN_USER_ID);
+      expect(cache().hdel).toBeCalledWith(CacheKeys.USER_PINS, BOBATAN_USER_ID);
       expect(cache().hdel).toBeCalledWith(
         CacheKeys.BOARD,
         MAIN_STREET_BOARD_ID
@@ -119,9 +119,12 @@ describe("Tests unmute boards REST API", () => {
       expect(res.status).toBe(204);
       // Ensure that the user cache was cleared since that contains the muted boards.
       // TODO: this is an implementation details and it should be tested by checking the
-      // users/@me endpoint.
+      // users/@me/pins/realm/:realm_id endpoint.
       expect(cache().hdel).toBeCalledTimes(2);
-      expect(cache().hdel).toBeCalledWith(CacheKeys.USER, JERSEY_DEVIL_USER_ID);
+      expect(cache().hdel).toBeCalledWith(
+        CacheKeys.USER_PINS,
+        JERSEY_DEVIL_USER_ID
+      );
       expect(cache().hdel).toBeCalledWith(CacheKeys.BOARD, MUTED_BOARD_ID);
 
       const boardMetadata = await request(server.app).get(`/${MUTED_BOARD_ID}`);

--- a/server/boards/tests/routes/pin-board.test.ts
+++ b/server/boards/tests/routes/pin-board.test.ts
@@ -12,6 +12,7 @@ import {
   wrapWithTransaction,
 } from "utils/test-utils";
 
+import { TWISTED_MINDS_REALM_STRING_ID } from "test/data/realms";
 import request from "supertest";
 import router from "../../routes";
 
@@ -56,9 +57,9 @@ describe("Tests pin boards REST API", () => {
 
       // Ensure that the user cache was cleared since that contains the pinned boards.
       // TODO: this is an implementation details and it should be tested by checking the
-      // users/@me endpoint.
+      // users/@me/pins/realm/:realm_id endpoint.
       expect(cache().hdel).toBeCalledTimes(2);
-      expect(cache().hdel).toBeCalledWith(CacheKeys.USER, BOBATAN_USER_ID);
+      expect(cache().hdel).toBeCalledWith(CacheKeys.USER_PINS, BOBATAN_USER_ID);
       expect(cache().hdel).toBeCalledWith(
         CacheKeys.BOARD,
         MAIN_STREET_BOARD_ID
@@ -114,9 +115,9 @@ describe("Tests unpin boards REST API", () => {
 
       // Ensure that the user cache was cleared since that contains the pinned boards.
       // TODO: this is an implementation details and it should be tested by checking the
-      // users/@me endpoint.
+      // users/@me/pins/realm/:realm_id endpoint.
       expect(cache().hdel).toBeCalledTimes(2);
-      expect(cache().hdel).toBeCalledWith(CacheKeys.USER, BOBATAN_USER_ID);
+      expect(cache().hdel).toBeCalledWith(CacheKeys.USER_PINS, BOBATAN_USER_ID);
       expect(cache().hdel).toBeCalledWith(CacheKeys.BOARD, GORE_BOARD_ID);
       expect(res.status).toBe(204);
 

--- a/server/boards/tests/routes/pin-board.test.ts
+++ b/server/boards/tests/routes/pin-board.test.ts
@@ -4,6 +4,7 @@ import {
   GORE_BOARD_ID,
   GORE_BOARD_METADATA,
   MAIN_STREET_BOARD_ID,
+  RESTRICTED_BOARD_ID,
 } from "test/data/boards";
 import {
   setLoggedInUser,
@@ -36,15 +37,15 @@ describe("Tests pin boards REST API", () => {
     expect(res.status).toBe(404);
   });
 
-  //   test("Should return 403 if user does not have required permissions", async () => {
-  //     setLoggedInUser(JERSEY_DEVIL_USER_ID);
-  //     const res = await request(server.app).post(`/${GORE_BOARD_ID}/pin`);
+  test("Should return 403 if user does not have required permissions", async () => {
+    setLoggedInUser(JERSEY_DEVIL_USER_ID);
+    const res = await request(server.app).post(`/${RESTRICTED_BOARD_ID}/pin`);
 
-  //     expect(res.status).toBe(403);
-  //     expect(res.body).toEqual({
-  //       message: `User cannot access board with id "c6d3d10e-8e49-4d73-b28a-9d652b41beec".`,
-  //     });
-  //   });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      message: "User does not have required permission to access board.",
+    });
+  });
 
   test("Should pin board", async () => {
     await wrapWithTransaction(async () => {
@@ -94,15 +95,15 @@ describe("Tests unpin boards REST API", () => {
     });
   });
 
-  //   test("Should return 403 if user does not have required permissions", async () => {
-  //     setLoggedInUser(JERSEY_DEVIL_USER_ID);
-  //     const res = await request(server.app).delete(`/${GORE_BOARD_ID}/pin`);
+  test("Should return 403 if user does not have required permissions", async () => {
+    setLoggedInUser(JERSEY_DEVIL_USER_ID);
+    const res = await request(server.app).delete(`/${RESTRICTED_BOARD_ID}/pin`);
 
-  //     expect(res.status).toBe(403);
-  //     expect(res.body).toEqual({
-  //       message: `User cannot access board with id "c6d3d10e-8e49-4d73-b28a-9d652b41beec".`,
-  //     });
-  //   });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      message: "User does not have required permission to access board.",
+    });
+  });
 
   test("Should unpin board", async () => {
     await wrapWithTransaction(async () => {

--- a/server/boards/tests/routes/update-board-metadata.test.ts
+++ b/server/boards/tests/routes/update-board-metadata.test.ts
@@ -11,8 +11,11 @@ import {
   wrapWithTransaction,
 } from "utils/test-utils";
 
+import debug from "debug";
 import request from "supertest";
 import router from "../../routes";
+
+const log = debug("bobaserver:test:boards:routes:update-board-metadata-log");
 
 jest.mock("server/cache");
 jest.mock("handlers/auth");

--- a/server/boards/utils.ts
+++ b/server/boards/utils.ts
@@ -141,9 +141,11 @@ export const getMetadataDelta = ({
 export const getBoardMetadataByUuid = async ({
   boardId,
   firebaseId,
+  hasBoardAccess,
 }: {
   boardId: string;
   firebaseId?: string;
+  hasBoardAccess: boolean;
 }) => {
   if (!firebaseId) {
     const cachedBoard = await cache().hget(CacheKeys.BOARD_METADATA, boardId);
@@ -166,10 +168,12 @@ export const getBoardMetadataByUuid = async ({
   const boardSummary = processBoardsSummary({
     boards: [board],
     isLoggedIn: !!firebaseId,
+    hasRealmMemberAccess: hasBoardAccess,
   });
   const boardMetadata = processBoardMetadata({
     metadata: board,
     isLoggedIn: !!firebaseId,
+    hasBoardAccess,
   });
   const finalMetadata = {
     ...boardSummary[0],

--- a/server/cache.ts
+++ b/server/cache.ts
@@ -69,4 +69,6 @@ export enum CacheKeys {
   USER = "USER",
   // Data pertaining to user settings, keyed by the user's firebase id.
   USER_SETTINGS = "USER_SETTINGS",
+  // Data pertaining to the user's pinned boards, keyed by the user's firebase id.
+  USER_PINS = "USER_PINS",
 }

--- a/server/posts/tests/routes/create-post.test.ts
+++ b/server/posts/tests/routes/create-post.test.ts
@@ -11,7 +11,7 @@ import {
   wrapWithTransaction,
 } from "utils/test-utils";
 
-import { BOBATAN_USER_ID } from "test/data/auth";
+import { BOBATAN_USER_ID, ZODIAC_KILLER_USER_ID } from "test/data/auth";
 import { CHARACTER_TO_MAIM_POST_ID } from "test/data/posts";
 import { EventEmitter } from "events";
 import { Post } from "types/rest/threads";
@@ -33,6 +33,26 @@ describe("Test creating new post REST API", () => {
 
   test("doesn't allow replying to post when logged out", async () => {
     await wrapWithTransaction(async () => {
+      const res = await request(server.app)
+        .post(`/${CHARACTER_TO_MAIM_POST_ID}/contributions`)
+        .send({
+          content: "this is a new contribution",
+          index_tags: [],
+          category_tags: [],
+          content_warnings: ["new_warning_1"],
+          whisper_tags: [],
+        });
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({
+        message: "No authenticated user found.",
+      });
+    });
+  });
+
+  test("doesn't allow replying to post when user not a member of realm", async () => {
+    await wrapWithTransaction(async () => {
+      setLoggedInUser(ZODIAC_KILLER_USER_ID);
       const res = await request(server.app)
         .post(`/${CHARACTER_TO_MAIM_POST_ID}/contributions`)
         .send({

--- a/server/posts/tests/routes/create-post.test.ts
+++ b/server/posts/tests/routes/create-post.test.ts
@@ -1,5 +1,6 @@
 import * as uuid from "uuid";
 
+import { BOBATAN_USER_ID, ZODIAC_KILLER_USER_ID } from "test/data/auth";
 import {
   EVENT_TYPES as THREAD_EVENT_TYPES,
   ThreadUpdatedPayload,
@@ -11,13 +12,15 @@ import {
   wrapWithTransaction,
 } from "utils/test-utils";
 
-import { BOBATAN_USER_ID, ZODIAC_KILLER_USER_ID } from "test/data/auth";
 import { CHARACTER_TO_MAIM_POST_ID } from "test/data/posts";
 import { EventEmitter } from "events";
 import { Post } from "types/rest/threads";
+import debug from "debug";
 import { mocked } from "ts-jest/utils";
 import request from "supertest";
 import router from "../../routes";
+
+const log = debug("bobaserver:posts:create-post-test-log");
 
 jest.mock("handlers/auth");
 jest.mock("server/db-pool");
@@ -63,9 +66,9 @@ describe("Test creating new post REST API", () => {
           whisper_tags: [],
         });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(403);
       expect(res.body).toEqual({
-        message: "No authenticated user found.",
+        message: "User does not have required permissions for realm operation.",
       });
     });
   });

--- a/server/realms/examples/by-slug-responses.yaml
+++ b/server/realms/examples/by-slug-responses.yaml
@@ -32,7 +32,13 @@ components:
                   title: This is a hidden rule
                   description: Congratulations! Here's a cookie
                   pinned: false
-        realm_permissions: [create_realm_invite]
+        realm_permissions:
+          [
+            create_realm_invite,
+            post_on_realm,
+            comment_on_realm,
+            access_member_only_content_on_realm,
+          ]
         boards:
           - id: 2fb151eb-c600-4fe4-a542-4662487e5496
             realm_id: 76ef4cc3-1603-4278-95d7-99c59f481d2e

--- a/server/realms/examples/by-slug-responses.yaml
+++ b/server/realms/examples/by-slug-responses.yaml
@@ -37,7 +37,8 @@ components:
             create_realm_invite,
             post_on_realm,
             comment_on_realm,
-            access_member_only_content_on_realm,
+            create_thread_on_realm,
+            access_locked_boards_on_realm,
           ]
         boards:
           - id: 2fb151eb-c600-4fe4-a542-4662487e5496

--- a/server/realms/queries.ts
+++ b/server/realms/queries.ts
@@ -8,6 +8,7 @@ import { filterOutDisabledSettings, getRealmCursorSetting } from "./utils";
 
 import { CssVariableSetting } from "../../types/settings";
 import { ITask } from "pg-promise";
+import { REALM_MEMBER_PERMISSIONS } from "types/permissions";
 import { SettingEntry } from "../../types/settings";
 import debug from "debug";
 import { extractRealmPermissions } from "utils/permissions-utils";
@@ -168,10 +169,10 @@ export const getRealmIdsByUuid = async ({
 
 export const getUserPermissionsForRealm = async ({
   firebaseId,
-  realmId,
+  realmStringId,
 }: {
   firebaseId: string | undefined;
-  realmId: string;
+  realmStringId: string;
 }) => {
   try {
     if (!firebaseId) {
@@ -181,7 +182,7 @@ export const getUserPermissionsForRealm = async ({
       sql.getUserPermissionsForRealm,
       {
         user_id: firebaseId,
-        realm_id: realmId,
+        realm_string_id: realmStringId,
       }
     );
     if (!userPermissionsGroupedByRole.length) {
@@ -198,6 +199,10 @@ export const getUserPermissionsForRealm = async ({
       },
       []
     );
+    const realmMember = checkUserOnRealm({ firebaseId, realmStringId });
+    if (realmMember) {
+      return [...allUserRealmPermissions, ...REALM_MEMBER_PERMISSIONS];
+    }
     return allUserRealmPermissions;
   } catch (e) {
     error(`Error while getting user permissions for the realm.`);

--- a/server/realms/queries.ts
+++ b/server/realms/queries.ts
@@ -176,7 +176,7 @@ export const getUserPermissionsForRealm = async ({
 }) => {
   try {
     if (!firebaseId) {
-      return null;
+      return [];
     }
     const userPermissionsGroupedByRole = await pool.manyOrNone(
       sql.getUserPermissionsForRealm,
@@ -186,7 +186,7 @@ export const getUserPermissionsForRealm = async ({
       }
     );
     if (!userPermissionsGroupedByRole.length) {
-      return null;
+      return [];
     }
     const userRealmPermissionsGroupedByRoles = userPermissionsGroupedByRole.map(
       (row) => {

--- a/server/realms/routes.ts
+++ b/server/realms/routes.ts
@@ -15,7 +15,11 @@ import {
 } from "server/realms/queries";
 import { createNewUser, getUserFromFirebaseId } from "server/users/queries";
 import { ensureLoggedIn, withLoggedIn, withUserSettings } from "handlers/auth";
-import { ensureRealmExists, ensureRealmPermission } from "handlers/permissions";
+import {
+  ensureRealmExists,
+  ensureRealmPermission,
+  withRealmPermissions,
+} from "handlers/permissions";
 import { getRealmDataBySlug, getSettingsBySlug } from "./queries";
 import {
   processBoardsNotifications,
@@ -105,6 +109,9 @@ router.get("/slug/:realm_slug", withUserSettings, async (req, res) => {
     const realmBoards = processBoardsSummary({
       boards,
       isLoggedIn: !!req.currentUser?.uid,
+      hasRealmMemberAccess: realmPermissions.includes(
+        RealmPermissions.accessMemberOnlyContentOnRealm
+      ),
     });
     res.status(200).json({
       id: realmData.id,
@@ -581,6 +588,8 @@ router.post(
   }
 );
 
+// This is an old version of the route at line 411, without the requires_email field in the response.
+// Should I delete it?
 /**
  * @openapi
  * /realms/{realm_id}/invites/{nonce}:

--- a/server/realms/routes.ts
+++ b/server/realms/routes.ts
@@ -90,7 +90,7 @@ router.get("/slug/:realm_slug", withUserSettings, async (req, res) => {
 
     const realmPermissions = await getUserPermissionsForRealm({
       firebaseId: req.currentUser?.uid,
-      realmId: realmData.id,
+      realmStringId: realmData.id,
     });
 
     const boards = await getBoards({

--- a/server/realms/routes.ts
+++ b/server/realms/routes.ts
@@ -105,7 +105,7 @@ router.get("/slug/:realm_slug", withUserSettings, async (req, res) => {
     if (!boards) {
       res.status(500);
     }
-
+    log("realmPermissions", realmPermissions);
     const realmBoards = processBoardsSummary({
       boards,
       isLoggedIn: !!req.currentUser?.uid,

--- a/server/realms/routes.ts
+++ b/server/realms/routes.ts
@@ -110,7 +110,7 @@ router.get("/slug/:realm_slug", withUserSettings, async (req, res) => {
       boards,
       isLoggedIn: !!req.currentUser?.uid,
       hasRealmMemberAccess: realmPermissions.includes(
-        RealmPermissions.accessMemberOnlyContentOnRealm
+        RealmPermissions.accessLockedBoardsOnRealm
       ),
     });
     res.status(200).json({

--- a/server/realms/sql/index.ts
+++ b/server/realms/sql/index.ts
@@ -20,7 +20,7 @@ const getUserPermissionsForRealm = `
       JOIN realm_user_roles ON users.id = realm_user_roles.user_id
       JOIN roles ON realm_user_roles.role_id = roles.id
       JOIN realms ON realm_user_roles.realm_id = realms.id 
-    WHERE users.firebase_id = $/user_id/ AND realms.string_id = $/realm_id/`;
+    WHERE users.firebase_id = $/user_id/ AND realms.string_id = $/realm_string_id/`;
 
 const createRealmInvite = `
     INSERT INTO account_invites(nonce, realm_id, inviter, invitee_email, label, duration)

--- a/server/realms/tests/realm-data.test.ts
+++ b/server/realms/tests/realm-data.test.ts
@@ -4,6 +4,7 @@ import { GORE_BOARD_METADATA, extractBoardSummary } from "test/data/boards";
 import express, { Express } from "express";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
+import { BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS } from "test/data/user";
 import { TWISTED_MINDS_REALM_SLUG } from "test/data/realms";
 import request from "supertest";
 import router from "../routes";
@@ -94,38 +95,10 @@ describe("Tests restricted board realm queries", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(res.body.realm_permissions.length).toBe(1);
-    expect(res.body.realm_permissions[0]).toEqual("create_realm_invite");
-  });
-
-  test("doesn't fetch realm permissions when user doesn't have realm permissions", async () => {
-    setLoggedInUser(JERSEY_DEVIL_USER_ID);
-    const res = await request(server.app).get(
-      `/slug/${TWISTED_MINDS_REALM_SLUG}`
+    expect(res.body.realm_permissions.length).toBe(4);
+    expect(res.body.realm_permissions).toEqual(
+      BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS
     );
-
-    expect(res.status).toBe(200);
-    expect(res.body.realm_permissions).toEqual([]);
-  });
-
-  test("doesn't fetch realm permissions when logged out", async () => {
-    const res = await request(server.app).get(
-      `/slug/${TWISTED_MINDS_REALM_SLUG}`
-    );
-
-    expect(res.status).toBe(200);
-    expect(res.body.realm_permissions).toEqual([]);
-  });
-
-  test("fetches user realm permissions when user has realm permissions", async () => {
-    setLoggedInUser(BOBATAN_USER_ID);
-    const res = await request(server.app).get(
-      `/slug/${TWISTED_MINDS_REALM_SLUG}`
-    );
-
-    expect(res.status).toBe(200);
-    expect(res.body.realm_permissions.length).toBe(1);
-    expect(res.body.realm_permissions[0]).toEqual("create_realm_invite");
   });
 
   test("doesn't fetch realm permissions when user doesn't have realm permissions", async () => {

--- a/server/realms/tests/realm-data.test.ts
+++ b/server/realms/tests/realm-data.test.ts
@@ -95,7 +95,7 @@ describe("Tests restricted board realm queries", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(res.body.realm_permissions.length).toBe(4);
+    expect(res.body.realm_permissions.length).toBe(BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS.length);
     expect(res.body.realm_permissions).toEqual(
       BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS
     );

--- a/server/realms/tests/restricted.test.ts
+++ b/server/realms/tests/restricted.test.ts
@@ -1,7 +1,7 @@
+import { BOBATAN_USER_ID, ZODIAC_KILLER_USER_ID } from "test/data/auth";
 import express, { Express } from "express";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
-import { BOBATAN_USER_ID } from "test/data/auth";
 import { RESTRICTED_BOARD_SUMMARY } from "test/data/boards";
 import { Server } from "http";
 import request from "supertest";
@@ -23,6 +23,16 @@ describe("Tests restricted board realm queries", () => {
     });
 
     test("doesn't fetch restricted board details in realm query when logged out", async () => {
+      const res = await request(server.app).get("/slug/twisted-minds");
+
+      expect(res.status).toBe(200);
+      expect(
+        res.body.boards.find((board: any) => board.slug == "restricted")
+      ).toEqual(RESTRICTED_BOARD_SUMMARY.LOGGED_OUT);
+    });
+
+    test("doesn't fetch restricted board details in realm query when user is not a member of realm", async () => {
+      setLoggedInUser(ZODIAC_KILLER_USER_ID);
       const res = await request(server.app).get("/slug/twisted-minds");
 
       expect(res.status).toBe(200);

--- a/server/users/routes.ts
+++ b/server/users/routes.ts
@@ -113,7 +113,7 @@ router.get(
       boards,
       isLoggedIn: !!req.currentUser?.uid,
       hasRealmMemberAccess: req.currentRealmPermissions.includes(
-        RealmPermissions.accessMemberOnlyContentOnRealm
+        RealmPermissions.accessLockedBoardsOnRealm
       ),
     });
     const pins = summaries

--- a/server/users/tests/routes.test.ts
+++ b/server/users/tests/routes.test.ts
@@ -37,16 +37,11 @@ describe("Test users routes", () => {
     const cachedData = {
       avatar_url: "/this_was_cached.png",
       username: "super_cached",
-      pinned_boards: {
-        cached_board: {},
-      },
     };
     mocked(cache().hget).mockResolvedValueOnce(stringify(cachedData));
     setLoggedInUser(JERSEY_DEVIL_USER_ID);
 
-    const res = await request(server.app).get(
-      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
-    );
+    const res = await request(server.app).get(`/@me`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(cachedData);
@@ -55,31 +50,24 @@ describe("Test users routes", () => {
   });
 
   test("Prevents unauthorized access", async () => {
-    const res = await request(server.app).get(
-      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
-    );
+    const res = await request(server.app).get(`/@me`);
     expect(res.status).toBe(401);
   });
 
   test("Returns data for the logged in user", async () => {
     setLoggedInUser(JERSEY_DEVIL_USER_ID);
-    const res = await request(server.app).get(
-      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
-    );
+    const res = await request(server.app).get(`/@me`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       avatar_url: "/hannibal.png",
       username: "jersey_devil_69",
-      pinned_boards: {},
     });
   });
 
   test("caches logged in user data", async function () {
     setLoggedInUser(JERSEY_DEVIL_USER_ID);
 
-    const res = await request(server.app).get(
-      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
-    );
+    const res = await request(server.app).get(`/@me`);
     expect(res.status).toBe(200);
     expect(cache().hset).toBeCalledTimes(1);
     expect(cache().hset).toBeCalledWith(

--- a/server/users/tests/routes.test.ts
+++ b/server/users/tests/routes.test.ts
@@ -2,6 +2,7 @@ import { CacheKeys, cache } from "../../cache";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
 import { JERSEY_DEVIL_USER_ID } from "test/data/auth";
+import { TWISTED_MINDS_REALM_STRING_ID } from "test/data/realms";
 import debug from "debug";
 import { ensureLoggedIn } from "handlers/auth";
 import { getUserFromFirebaseId } from "../queries";
@@ -43,7 +44,9 @@ describe("Test users routes", () => {
     mocked(cache().hget).mockResolvedValueOnce(stringify(cachedData));
     setLoggedInUser(JERSEY_DEVIL_USER_ID);
 
-    const res = await request(server.app).get("/@me");
+    const res = await request(server.app).get(
+      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(cachedData);
@@ -52,13 +55,17 @@ describe("Test users routes", () => {
   });
 
   test("Prevents unauthorized access", async () => {
-    const res = await request(server.app).get("/@me");
+    const res = await request(server.app).get(
+      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
     expect(res.status).toBe(401);
   });
 
   test("Returns data for the logged in user", async () => {
     setLoggedInUser(JERSEY_DEVIL_USER_ID);
-    const res = await request(server.app).get("/@me");
+    const res = await request(server.app).get(
+      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       avatar_url: "/hannibal.png",
@@ -70,7 +77,9 @@ describe("Test users routes", () => {
   test("caches logged in user data", async function () {
     setLoggedInUser(JERSEY_DEVIL_USER_ID);
 
-    const res = await request(server.app).get("/@me");
+    const res = await request(server.app).get(
+      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
     expect(res.status).toBe(200);
     expect(cache().hset).toBeCalledTimes(1);
     expect(cache().hset).toBeCalledWith(

--- a/server/users/tests/routes/user-data.test.ts
+++ b/server/users/tests/routes/user-data.test.ts
@@ -1,8 +1,11 @@
+import {
+  TWISTED_MINDS_REALM_STRING_ID,
+  UWU_REALM_STRING_ID,
+} from "test/data/realms";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
 import { BOBATAN_USER_DATA } from "test/data/user";
 import { BOBATAN_USER_ID } from "test/data/auth";
-import { TWISTED_MINDS_REALM_STRING_ID } from "test/data/realms";
 import debug from "debug";
 import request from "supertest";
 import router from "../../routes";
@@ -15,17 +18,29 @@ describe("Tests boards REST API", () => {
   const server = startTestServer(router);
 
   test("should not return notifications data (logged out)", async () => {
-    const res = await request(server.app).get(`/@me/${TWISTED_MINDS_REALM_STRING_ID}`);
+    const res = await request(server.app).get(
+      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
 
     expect(res.status).toBe(401);
   });
 
   test("should return notifications data (logged in)", async () => {
     setLoggedInUser(BOBATAN_USER_ID);
-    const res = await request(server.app).get(`/@me/${TWISTED_MINDS_REALM_STRING_ID}`);
+    const res = await request(server.app).get(
+      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(BOBATAN_USER_DATA);
+  });
+
+  test("should only return pinned boards for current realm", async () => {
+    setLoggedInUser(BOBATAN_USER_ID);
+    const res = await request(server.app).get(`/@me/${UWU_REALM_STRING_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pinned_boards).toEqual({});
   });
 
   // TODO: check if any test user has outdated notifications or none, and test there

--- a/server/users/tests/routes/user-data.test.ts
+++ b/server/users/tests/routes/user-data.test.ts
@@ -1,10 +1,10 @@
+import { BOBATAN_PINNED_BOARDS, BOBATAN_USER_DATA } from "test/data/user";
 import {
   TWISTED_MINDS_REALM_STRING_ID,
   UWU_REALM_STRING_ID,
 } from "test/data/realms";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
-import { BOBATAN_USER_DATA } from "test/data/user";
 import { BOBATAN_USER_ID } from "test/data/auth";
 import debug from "debug";
 import request from "supertest";
@@ -17,27 +17,35 @@ jest.mock("handlers/auth");
 describe("Tests boards REST API", () => {
   const server = startTestServer(router);
 
-  test("should not return notifications data (logged out)", async () => {
-    const res = await request(server.app).get(
-      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
-    );
+  test("should not return user data (logged out)", async () => {
+    const res = await request(server.app).get(`/@me`);
 
     expect(res.status).toBe(401);
   });
 
-  test("should return notifications data (logged in)", async () => {
+  test("should return user data (logged in)", async () => {
     setLoggedInUser(BOBATAN_USER_ID);
-    const res = await request(server.app).get(
-      `/@me/${TWISTED_MINDS_REALM_STRING_ID}`
-    );
+    const res = await request(server.app).get(`/@me`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(BOBATAN_USER_DATA);
   });
 
+  test("should return pinned boards for current realm", async () => {
+    setLoggedInUser(BOBATAN_USER_ID);
+    const res = await request(server.app).get(
+      `/@me/pins/realms/${TWISTED_MINDS_REALM_STRING_ID}`
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(BOBATAN_PINNED_BOARDS);
+  });
+
   test("should only return pinned boards for current realm", async () => {
     setLoggedInUser(BOBATAN_USER_ID);
-    const res = await request(server.app).get(`/@me/${UWU_REALM_STRING_ID}`);
+    const res = await request(server.app).get(
+      `/@me/pins/realms/${UWU_REALM_STRING_ID}`
+    );
 
     expect(res.status).toBe(200);
     expect(res.body.pinned_boards).toEqual({});

--- a/server/users/tests/routes/user-data.test.ts
+++ b/server/users/tests/routes/user-data.test.ts
@@ -2,6 +2,7 @@ import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
 import { BOBATAN_USER_DATA } from "test/data/user";
 import { BOBATAN_USER_ID } from "test/data/auth";
+import { TWISTED_MINDS_REALM_STRING_ID } from "test/data/realms";
 import debug from "debug";
 import request from "supertest";
 import router from "../../routes";
@@ -14,14 +15,14 @@ describe("Tests boards REST API", () => {
   const server = startTestServer(router);
 
   test("should not return notifications data (logged out)", async () => {
-    const res = await request(server.app).get(`/@me`);
+    const res = await request(server.app).get(`/@me/${TWISTED_MINDS_REALM_STRING_ID}`);
 
     expect(res.status).toBe(401);
   });
 
   test("should return notifications data (logged in)", async () => {
     setLoggedInUser(BOBATAN_USER_ID);
-    const res = await request(server.app).get(`/@me`);
+    const res = await request(server.app).get(`/@me/${TWISTED_MINDS_REALM_STRING_ID}`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(BOBATAN_USER_DATA);

--- a/test/data/user.ts
+++ b/test/data/user.ts
@@ -1,3 +1,5 @@
+import { REALM_MEMBER_PERMISSIONS, RealmPermissions } from "types/permissions";
+
 import { UserData } from "../../types/rest/user";
 
 export const BOBATAN_USER_DATA: UserData = {
@@ -37,3 +39,8 @@ export const ONCEST_USER_IDENTITY = {
   avatar: "/greedler.jpg",
   name: "oncest5evah",
 };
+
+export const BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS = [
+  RealmPermissions.createRealmInvite,
+  ...REALM_MEMBER_PERMISSIONS,
+];

--- a/test/data/user.ts
+++ b/test/data/user.ts
@@ -4,6 +4,10 @@ import { UserData } from "../../types/rest/user";
 
 export const BOBATAN_USER_DATA: UserData = {
   avatar_url: "/bobatan.png",
+  username: "bobatan",
+};
+
+export const BOBATAN_PINNED_BOARDS = {
   pinned_boards: {
     anime: {
       accent_color: "#24d282",
@@ -32,7 +36,6 @@ export const BOBATAN_USER_DATA: UserData = {
       tagline: "Blood! Blood! Blood!",
     },
   },
-  username: "bobatan",
 };
 
 export const ONCEST_USER_IDENTITY = {

--- a/types/open-api/permissions.yaml
+++ b/types/open-api/permissions.yaml
@@ -39,4 +39,10 @@ components:
       type: array
       items:
         type: string
-        enum: [create_realm_invite]
+        enum:
+          [
+            create_realm_invite,
+            post_on_realm,
+            comment_on_realm,
+            access_member_only_content_on_realm,
+          ]

--- a/types/open-api/permissions.yaml
+++ b/types/open-api/permissions.yaml
@@ -44,5 +44,6 @@ components:
             create_realm_invite,
             post_on_realm,
             comment_on_realm,
-            access_member_only_content_on_realm,
+            create_thread_on_realm,
+            access_locked_boards_on_realm,
           ]

--- a/types/permissions.ts
+++ b/types/permissions.ts
@@ -18,6 +18,9 @@ export enum DbRolePermissions {
   edit_index_tags = "edit_index_tags",
   edit_default_view = "edit_default_view",
   create_realm_invite = "create_realm_invite",
+  post_on_realm = "post_on_realm",
+  comment_on_realm = "comment_on_realm",
+  access_member_only_content_on_realm = "access_member_only_content_on_realm",
 }
 
 export interface UserBoardPermissions {
@@ -37,6 +40,11 @@ export enum BoardPermissions {
 
 export enum RealmPermissions {
   createRealmInvite = DbRolePermissions["create_realm_invite"],
+  postOnRealm = DbRolePermissions["post_on_realm"],
+  commentOnRealm = DbRolePermissions["comment_on_realm"],
+  accessMemberOnlyContentOnRealm = DbRolePermissions[
+    "access_member_only_content_on_realm"
+  ],
 }
 
 export enum PostPermissions {
@@ -79,6 +87,15 @@ export const POST_OWNER_PERMISSIONS = [
  * The set of thread permissions associated with every thread owner.
  */
 export const THREAD_OWNER_PERMISSIONS = [ThreadPermissions.editDefaultView];
+
+/**
+ * The set of realm permissions associated with every realm member.
+ */
+export const REALM_MEMBER_PERMISSIONS = [
+  RealmPermissions.accessMemberOnlyContentOnRealm,
+  RealmPermissions.commentOnRealm,
+  RealmPermissions.postOnRealm,
+];
 
 export enum BoardRestrictions {
   LOCK_ACCESS = "lock_access",

--- a/types/permissions.ts
+++ b/types/permissions.ts
@@ -20,7 +20,8 @@ export enum DbRolePermissions {
   create_realm_invite = "create_realm_invite",
   post_on_realm = "post_on_realm",
   comment_on_realm = "comment_on_realm",
-  access_member_only_content_on_realm = "access_member_only_content_on_realm",
+  create_thread_on_realm = "create_thread_on_realm",
+  access_locked_boards_on_realm = "access_locked_boards_on_realm",
 }
 
 export interface UserBoardPermissions {
@@ -42,8 +43,9 @@ export enum RealmPermissions {
   createRealmInvite = DbRolePermissions["create_realm_invite"],
   postOnRealm = DbRolePermissions["post_on_realm"],
   commentOnRealm = DbRolePermissions["comment_on_realm"],
-  accessMemberOnlyContentOnRealm = DbRolePermissions[
-    "access_member_only_content_on_realm"
+  createThreadOnRealm = DbRolePermissions["create_thread_on_realm"],
+  accessLockedBoardsOnRealm = DbRolePermissions[
+    "access_locked_boards_on_realm"
   ],
 }
 
@@ -92,9 +94,10 @@ export const THREAD_OWNER_PERMISSIONS = [ThreadPermissions.editDefaultView];
  * The set of realm permissions associated with every realm member.
  */
 export const REALM_MEMBER_PERMISSIONS = [
-  RealmPermissions.accessMemberOnlyContentOnRealm,
+  RealmPermissions.accessLockedBoardsOnRealm,
   RealmPermissions.commentOnRealm,
   RealmPermissions.postOnRealm,
+  RealmPermissions.createThreadOnRealm,
 ];
 
 export enum BoardRestrictions {


### PR DESCRIPTION
Adds default realm member permissions for posting, commenting, and accessing member-only content, and  gates routes with appropriate permissions.

Additional changes done because I needed them:

- `getBoardByUuid` query now returns `parent_realm_id`
- `GET users/@me` route now realm specific `GET users/@me/{realm_id})`, and only returns pinned boards for the current realm.