### PR TITLE
fix and test realm member permissions

### DIFF
--- a/db/test_db_init/000_insert.sql
+++ b/db/test_db_init/000_insert.sql
@@ -68,13 +68,15 @@ VALUES
     ('fb4', 'SexyDaddy69', 'mamoru.png', (SELECT id FROM users WHERE username='oncest5evah')),
     ('fb5', 'The Zodiac Killer', 'villains.png', (SELECT id FROM users WHERE username='oncest5evah'));
 
+-- If you update the realms the users are members of, please update the comments in tests/data/auth.ts
 INSERT INTO realm_users(realm_id, user_id)
 VALUES
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'), (SELECT id FROM users WHERE username = 'bobatan')),
     ((SELECT id FROM realms WHERE slug = 'uwu'), (SELECT id FROM users WHERE username = 'bobatan')),
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'), (SELECT id FROM users WHERE username = 'SexyDaddy69')),
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'), (SELECT id FROM users WHERE username = 'oncest5evah')),
-    ((SELECT id FROM realms WHERE slug = 'uwu'), (SELECT id FROM users WHERE username = 'The Zodiac Killer'));
+    ((SELECT id FROM realms WHERE slug = 'uwu'), (SELECT id FROM users WHERE username = 'The Zodiac Killer')),
+    ((SELECT id FROM realms WHERE slug = 'uwu'), (SELECT id FROM users WHERE username = 'SexyDaddy69'));
 
 -- Set the incremental values of the tables we have overrode the system values of
 -- See: https://stackoverflow.com/questions/9108833/postgres-autoincrement-not-updated-on-explicit-id-inserts

--- a/db/test_db_init/070_roles_insert.sql
+++ b/db/test_db_init/070_roles_insert.sql
@@ -1,3 +1,4 @@
+-- If you update the roles or the users they are assigned to, please update the comments in tests/data/auth.ts
 INSERT INTO roles(string_id, name, avatar_reference_id, color, description, permissions)
 VALUES
     ('e5f86f53-6dcd-4f15-b6ea-6ca1f088e62d', 'GoreMaster5000', 'https://firebasestorage.googleapis.com/v0/b/bobaboard-fb.appspot.com/o/images%2Fbobaland%2Fc26e8ce9-a547-4ff4-9486-7a2faca4d873%2F6518df53-2031-4ac5-8d75-57a0051ed924?alt=media&token=23df54b7-297c-42ff-a0ea-b9862c9814f8', 

--- a/server/realms/queries.ts
+++ b/server/realms/queries.ts
@@ -189,7 +189,14 @@ export const getUserPermissionsForRealm = async ({
         realm_string_id: realmStringId,
       }
     );
+    const realmMember = await checkUserOnRealm({ firebaseId, realmStringId });
+    log("realmMember", realmMember);
     if (!userPermissionsGroupedByRole.length) {
+      if (realmMember) {
+        log("returning realm member permissions");
+        return [...REALM_MEMBER_PERMISSIONS];
+      }
+      log("returning empty realm permissions");
       return [];
     }
     const allUserRolePermissions = userPermissionsGroupedByRole.reduce(
@@ -205,7 +212,6 @@ export const getUserPermissionsForRealm = async ({
     const userRoleRealmPermissions = extractRealmPermissions(
       allUserRolePermissions
     );
-    const realmMember = checkUserOnRealm({ firebaseId, realmStringId });
     if (realmMember) {
       return [...userRoleRealmPermissions, ...REALM_MEMBER_PERMISSIONS];
     }

--- a/server/realms/tests/invites.test.ts
+++ b/server/realms/tests/invites.test.ts
@@ -863,7 +863,11 @@ describe("Tests accept invites endpoint", () => {
         firebase_id: NEW_USER_FIREBASE_ID,
       });
 
-      const preExistingUsersInRealm = [BOBATAN_USER_ID, ZODIAC_KILLER_USER_ID];
+      const preExistingUsersInRealm = [
+        BOBATAN_USER_ID,
+        ZODIAC_KILLER_USER_ID,
+        SEXY_DADDY_USER_ID,
+      ];
       const usersInRealm = await pool.many(
         `SELECT users.firebase_id
       FROM realm_users
@@ -915,7 +919,11 @@ describe("Tests accept invites endpoint", () => {
         firebase_id: NEW_USER_FIREBASE_ID,
       });
 
-      const preExistingUsersInRealm = [BOBATAN_USER_ID, ZODIAC_KILLER_USER_ID];
+      const preExistingUsersInRealm = [
+        BOBATAN_USER_ID,
+        ZODIAC_KILLER_USER_ID,
+        SEXY_DADDY_USER_ID,
+      ];
       const usersInRealm = await pool.many(
         `SELECT users.firebase_id
         FROM realm_users

--- a/server/realms/tests/realm-data.test.ts
+++ b/server/realms/tests/realm-data.test.ts
@@ -1,11 +1,16 @@
-import { BOBATAN_USER_ID, JERSEY_DEVIL_USER_ID } from "test/data/auth";
+import {
+  BOBATAN_USER_ID,
+  JERSEY_DEVIL_USER_ID,
+  SEXY_DADDY_USER_ID,
+} from "test/data/auth";
 import { BoardMetadata, BoardSummary } from "types/rest/boards";
 import { GORE_BOARD_METADATA, extractBoardSummary } from "test/data/boards";
+import { TWISTED_MINDS_REALM_SLUG, UWU_REALM_SLUG } from "test/data/realms";
 import express, { Express } from "express";
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
 import { BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS } from "test/data/user";
-import { TWISTED_MINDS_REALM_SLUG } from "test/data/realms";
+import { REALM_MEMBER_PERMISSIONS } from "types/permissions";
 import request from "supertest";
 import router from "../routes";
 
@@ -95,10 +100,23 @@ describe("Tests restricted board realm queries", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(res.body.realm_permissions.length).toBe(BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS.length);
+    expect(res.body.realm_permissions.length).toBe(
+      BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS.length
+    );
     expect(res.body.realm_permissions).toEqual(
       BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS
     );
+  });
+
+  test("fetches user realm permissions when user is realm member without other roles on realm", async () => {
+    setLoggedInUser(SEXY_DADDY_USER_ID);
+    const res = await request(server.app).get(`/slug/${UWU_REALM_SLUG}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.realm_permissions.length).toBe(
+      REALM_MEMBER_PERMISSIONS.length
+    );
+    expect(res.body.realm_permissions).toEqual(REALM_MEMBER_PERMISSIONS);
   });
 
   test("doesn't fetch realm permissions when user doesn't have realm permissions", async () => {

--- a/test/data/auth.ts
+++ b/test/data/auth.ts
@@ -1,6 +1,33 @@
+// bobatan:
+// twisted-minds realm: member,
+//   The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite),
+//   GoreMaster5000 (edit_board_details, post_as_role, edit_category_tags, edit_content_notices)
+// uwu realm: member,
+//   The Memester (all)
+// gore board: GoreMaster5000 (edit_board_details, post_as_role, edit_category_tags, edit_content_notices)
+// memes board: The Memester (all)
 export const BOBATAN_USER_ID = "c6HimTlg2RhVH3fC1psXZORdLcx2";
+
+// jersey_devil_69:
+// twisted-minds realm:
+// uwu realm:
 export const JERSEY_DEVIL_USER_ID = "fb2";
+
+// oncest5evah:
+// twisted-minds realm: member,
+//   GoreMaster5000 (edit_board_details, post_as_role, edit_category_tags, edit_content_notices)
+// uwu realm:
 export const ONCEST_USER_ID = "fb3";
+
+// SexyDaddy69:
+// twisted-minds realm: member,
+//   The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite)
+// uwu realm: member
 export const SEXY_DADDY_USER_ID = "fb4";
+
+// The Zodiac Killer:
+// twisted-minds realm:
+// uwu realm: member, The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite)
 export const ZODIAC_KILLER_USER_ID = "fb5";
+
 export const GORE_MASTER_IDENTITY_ID = "e5f86f53-6dcd-4f15-b6ea-6ca1f088e62d";


### PR DESCRIPTION
Ensures realm members without other role receive realm member permission.

Also adds comments to document the test users' roles and realm memberships.