### PR TITLE
Chore/todo tests

### DIFF
--- a/server/boards/tests/routes/create-thread.test.ts
+++ b/server/boards/tests/routes/create-thread.test.ts
@@ -62,7 +62,9 @@ describe("Tests threads REST API - create", () => {
   });
 
   // TODO: don't know how to generate invalid token
-  test("TODO: should fail when user has invalid authentication", async () => {
+  test.todo(
+    "should fail when user has invalid authentication"
+    // , async () => {
     //await wrapWithTransaction(async () => {
     //const res = await request(server.app)
     //  .post(`/${GORE_BOARD_ID}`)
@@ -70,10 +72,13 @@ describe("Tests threads REST API - create", () => {
     //expect(res.status).toBe(401);
     //expect(res.body).toEqual<GenericResponse>(ENSURE_LOGGED_IN_INVALID_TOKEN);
     //});
-  });
+    // }
+  );
 
   // Currently no specific permission for creating a thread exists
-  test("TODO: should fail when user does not have permissions", async () => {
+  test.todo(
+    "should fail when user does not have permissions"
+    // , async () => {
     //await wrapWithTransaction(async () => {
     //  setLoggedInUser(BOBATAN_USER_ID);
     //  const res = await request(server.app)
@@ -81,7 +86,8 @@ describe("Tests threads REST API - create", () => {
     //    .send(CREATE_GORE_THREAD_BASE_REQUEST);
     //  expect(res.status).toBe(403);
     //});
-  });
+    // }
+  );
 
   test("should fail when board does not exist", async () => {
     await wrapWithTransaction(async () => {
@@ -96,14 +102,17 @@ describe("Tests threads REST API - create", () => {
   });
 
   // No request body validation for  yet
-  test("TODO: should fail if request body is invalid", async () => {
+  test.todo(
+    "should fail if request body is invalid"
+    // , async () => {
     //await wrapWithTransaction(async () => {
     //  setLoggedInUser(BOBATAN_USER_ID);
     //  const res = await request(server.app)
     //    .post(`/${NULL_ID}`)
     //    .send(CREATE_GORE_THREAD_BASE_REQUEST);
     //  expect(res.status).toBe(422);
-  });
+    // }
+  );
 
   test("should create thread with accessory", async () => {
     await wrapWithTransaction(async () => {

--- a/server/posts/tests/restricted.test.ts
+++ b/server/posts/tests/restricted.test.ts
@@ -1,3 +1,3 @@
 describe("Tests restricted tests queries", () => {
-  test("TODO", async () => {});
+  test.todo("TODO");
 });

--- a/server/posts/tests/tags.test.ts
+++ b/server/posts/tests/tags.test.ts
@@ -3,6 +3,8 @@ import {
   maybeAddCategoryTags,
   maybeAddContentWarningTags,
   maybeAddIndexTags,
+  removeCategoryTags,
+  removeContentWarningTags,
   removeIndexTags,
   updateWhisperTags,
 } from "../queries";
@@ -15,6 +17,11 @@ const log = debug("bobaserver:posts:queries-test-log");
 
 const HIMBO_POST_ID = 6;
 const REVOLVER_OCELOT_POST_ID = 2;
+const VIDEO_GAME_MURDER_POST_ID = 4;
+const VIDEO_GAME_MURDER_POST_EXTERNAL_ID =
+  "3db477e0-57ed-491d-ba11-b3a0110b59b0";
+const NO_HARASSMENT_POST_ID = 173;
+const NO_HARASSMENT_POST_EXTERNAL_ID = "ff9f2ae2-a254-4069-9791-3ac5e6dff5bb";
 const HIMBO_POST_EXTERNAL_ID = "1f1ad4fa-f02a-48c0-a78a-51221a7db170";
 describe("Tests posts queries", () => {
   test("adds index tags to post (and database)", async () => {
@@ -82,7 +89,7 @@ describe("Tests posts queries", () => {
   });
 });
 
-test("removes tags from post", async () => {
+test("removes index tags from post", async () => {
   await runWithinTransaction(async (transaction) => {
     const postExternalId = REVOLVER_OCELOT_POST.id;
     await removeIndexTags(transaction, {
@@ -102,7 +109,46 @@ test("removes tags from post", async () => {
   });
 });
 
-// TODO: do the same for categories and content warnings
+test("removes category tags from post", async () => {
+  await runWithinTransaction(async (transaction) => {
+    const postExternalId = VIDEO_GAME_MURDER_POST_EXTERNAL_ID;
+
+    await removeCategoryTags(transaction, {
+      postId: VIDEO_GAME_MURDER_POST_ID,
+      categoryTags: ["bruises"],
+    });
+
+    const result = await getPostByExternalId(transaction, {
+      firebaseId: undefined,
+      postExternalId: postExternalId,
+    });
+
+    expect(result.category_tags).toIncludeSameMembers(["blood"]);
+  });
+});
+
+test("removes content warning tags from post", async () => {
+  await runWithinTransaction(async (transaction) => {
+    const postExternalId = NO_HARASSMENT_POST_EXTERNAL_ID;
+
+    await removeContentWarningTags(transaction, {
+      postId: NO_HARASSMENT_POST_ID,
+      contentWarnings: ["harassment PSA"],
+    });
+
+    const result = await getPostByExternalId(transaction, {
+      firebaseId: undefined,
+      postExternalId: postExternalId,
+    });
+
+    console.log("**************************");
+    console.log({ result });
+    console.log("**************************");
+
+
+    expect(result.content_warnings).toIncludeSameMembers([]);
+  });
+});
 
 test("updates whisper tags", async () => {
   await runWithinTransaction(async (transaction) => {

--- a/server/posts/tests/tags.test.ts
+++ b/server/posts/tests/tags.test.ts
@@ -23,7 +23,8 @@ const VIDEO_GAME_MURDER_POST_EXTERNAL_ID =
 const NO_HARASSMENT_POST_ID = 173;
 const NO_HARASSMENT_POST_EXTERNAL_ID = "ff9f2ae2-a254-4069-9791-3ac5e6dff5bb";
 const HIMBO_POST_EXTERNAL_ID = "1f1ad4fa-f02a-48c0-a78a-51221a7db170";
-describe("Tests posts queries", () => {
+
+describe("Tests tag-related queries", () => {
   test("adds index tags to post (and database)", async () => {
     await runWithinTransaction(async (transaction) => {
       const postId = HIMBO_POST_ID;
@@ -64,108 +65,108 @@ describe("Tests posts queries", () => {
       expect(result.content_warnings).toIncludeSameMembers(["zombies", "vore"]);
     });
   });
-
-  // TODO: I have no idea why but sometimes tests decide they should not
-  // pass on CI.
-  // Periodically, try to remove this cause sometimes they start passing again.
-  describe("ci-disable", () => {
-    test("adds category tags to post (and database)", async () => {
-      await runWithinTransaction(async (transaction) => {
-        const postId = HIMBO_POST_ID;
-        const addedTags = await maybeAddCategoryTags(transaction, {
-          postId,
-          categoryTags: ["thirst"],
-        });
-        expect(addedTags).toIncludeSameMembers(["thirst"]);
-
-        const result = await getPostByExternalId(transaction, {
-          firebaseId: undefined,
-          postExternalId: HIMBO_POST_EXTERNAL_ID,
-        });
-
-        expect(result.category_tags).toIncludeSameMembers(["thirst"]);
+  
+  test("adds category tags to post (and database)", async () => {
+    await runWithinTransaction(async (transaction) => {
+      const postId = HIMBO_POST_ID;
+      const addedTags = await maybeAddCategoryTags(transaction, {
+        postId,
+        categoryTags: ["thirst"],
       });
+      expect(addedTags).toIncludeSameMembers(["thirst"]);
+
+      const result = await getPostByExternalId(transaction, {
+        firebaseId: undefined,
+        postExternalId: HIMBO_POST_EXTERNAL_ID,
+      });
+
+      expect(result.category_tags).toIncludeSameMembers(["thirst"]);
     });
   });
-});
 
-test("removes index tags from post", async () => {
-  await runWithinTransaction(async (transaction) => {
-    const postExternalId = REVOLVER_OCELOT_POST.id;
-    await removeIndexTags(transaction, {
-      postId: REVOLVER_OCELOT_POST_ID,
-      indexTags: ["EVIL", "   metal gear      "],
+  test("removes index tags from post", async () => {
+    await runWithinTransaction(async (transaction) => {
+      const postExternalId = REVOLVER_OCELOT_POST.id;
+      await removeIndexTags(transaction, {
+        postId: REVOLVER_OCELOT_POST_ID,
+        indexTags: ["EVIL", "   metal gear      "],
+      });
+
+      const result = await getPostByExternalId(transaction, {
+        firebaseId: undefined,
+        postExternalId: postExternalId,
+      });
+
+      expect(result.index_tags).toIncludeSameMembers([
+        "bobapost",
+        "oddly specific",
+      ]);
     });
-
-    const result = await getPostByExternalId(transaction, {
-      firebaseId: undefined,
-      postExternalId: postExternalId,
-    });
-
-    expect(result.index_tags).toIncludeSameMembers([
-      "bobapost",
-      "oddly specific",
-    ]);
   });
-});
 
-test("removes category tags from post", async () => {
-  await runWithinTransaction(async (transaction) => {
-    const postExternalId = VIDEO_GAME_MURDER_POST_EXTERNAL_ID;
+  test("removes category tags from post", async () => {
+    await runWithinTransaction(async (transaction) => {
+      const postExternalId = VIDEO_GAME_MURDER_POST_EXTERNAL_ID;
 
-    await removeCategoryTags(transaction, {
-      postId: VIDEO_GAME_MURDER_POST_ID,
-      categoryTags: ["bruises"],
+      await removeCategoryTags(transaction, {
+        postId: VIDEO_GAME_MURDER_POST_ID,
+        categoryTags: ["bruises"],
+      });
+
+      const result = await getPostByExternalId(transaction, {
+        firebaseId: undefined,
+        postExternalId: postExternalId,
+      });
+
+      expect(result.category_tags).toIncludeSameMembers(["blood"]);
     });
-
-    const result = await getPostByExternalId(transaction, {
-      firebaseId: undefined,
-      postExternalId: postExternalId,
-    });
-
-    expect(result.category_tags).toIncludeSameMembers(["blood"]);
   });
-});
 
-test("removes content warning tags from post", async () => {
-  await runWithinTransaction(async (transaction) => {
-    const postExternalId = NO_HARASSMENT_POST_EXTERNAL_ID;
+  test("removes content warning tags from post", async () => {
+    await runWithinTransaction(async (transaction) => {
+      const postId = NO_HARASSMENT_POST_ID;
+      const postExternalId = NO_HARASSMENT_POST_EXTERNAL_ID;
 
-    await removeContentWarningTags(transaction, {
-      postId: NO_HARASSMENT_POST_ID,
-      contentWarnings: ["harassment PSA"],
+      // adding some content warnings to take them away; there is a known issue where the test will not take away the pre-existing content warning
+      await maybeAddContentWarningTags(transaction, {
+        postId,
+        contentWarnings: ["proclamation", "important thing"],
+      });
+
+      await removeContentWarningTags(transaction, {
+        postId,
+        contentWarnings: ["important thing"],
+      });
+
+      const result = await getPostByExternalId(transaction, {
+        firebaseId: undefined,
+        postExternalId,
+      });
+
+      expect(result.content_warnings).toIncludeSameMembers([
+        "harassment PSA",
+        "proclamation",
+      ]);
     });
-
-    const result = await getPostByExternalId(transaction, {
-      firebaseId: undefined,
-      postExternalId: postExternalId,
-    });
-
-    console.log("**************************");
-    console.log({ result });
-    console.log("**************************");
-
-
-    expect(result.content_warnings).toIncludeSameMembers([]);
   });
-});
 
-test("updates whisper tags", async () => {
-  await runWithinTransaction(async (transaction) => {
-    const postId = HIMBO_POST_ID;
-    await updateWhisperTags(transaction, {
-      postId,
-      whisperTags: ["whisper whisper", "babble babble"],
+  test("updates whisper tags", async () => {
+    await runWithinTransaction(async (transaction) => {
+      const postId = HIMBO_POST_ID;
+      await updateWhisperTags(transaction, {
+        postId,
+        whisperTags: ["whisper whisper", "babble babble"],
+      });
+
+      const result = await getPostByExternalId(transaction, {
+        firebaseId: undefined,
+        postExternalId: HIMBO_POST_EXTERNAL_ID,
+      });
+
+      expect(result.whisper_tags).toIncludeSameMembers([
+        "babble babble",
+        "whisper whisper",
+      ]);
     });
-
-    const result = await getPostByExternalId(transaction, {
-      firebaseId: undefined,
-      postExternalId: HIMBO_POST_EXTERNAL_ID,
-    });
-
-    expect(result.whisper_tags).toIncludeSameMembers([
-      "babble babble",
-      "whisper whisper",
-    ]);
   });
 });

--- a/server/threads/tests/routes/get-thread.test.ts
+++ b/server/threads/tests/routes/get-thread.test.ts
@@ -1,17 +1,16 @@
 import {
   FAVORITE_CHARACTER_THREAD,
   FAVORITE_CHARACTER_THREAD_ID,
-  RESTRICTED_THREAD,
-  RESTRICTED_THREAD_ID,
   NULL_ID,
   NULL_THREAD_NOT_FOUND,
+  RESTRICTED_THREAD,
+  RESTRICTED_THREAD_ID,
 } from "test/data/threads";
-
 import { setLoggedInUser, startTestServer } from "utils/test-utils";
 
 import { BOBATAN_USER_ID } from "test/data/auth";
-import { Thread } from "types/rest/threads";
 import { GenericResponse } from "types/rest/responses";
+import { Thread } from "types/rest/threads";
 import request from "supertest";
 import router from "../../routes";
 
@@ -43,11 +42,14 @@ describe("Tests threads REST API", () => {
     expect(res.body).toEqual<Thread>(RESTRICTED_THREAD);
   });
 
-  test("TODO: should lock when user does not have access to board", async () => {
+  test.todo(
+    "should lock when user does not have access to board"
+    // , async () => {
     //setLoggedInUser(BOBATAN_USER_ID);
     //expect(res.status).toBe(403);
     //expect(res.body).toEqual<Thread>(RESTRICTED_THREAD);
-  });
+    // }
+  );
 
   test("should fail when thread does not exist", async () => {
     setLoggedInUser(BOBATAN_USER_ID);

--- a/server/threads/tests/routes/hide-thread.test.ts
+++ b/server/threads/tests/routes/hide-thread.test.ts
@@ -48,22 +48,28 @@ describe("Tests threads REST API - hide", () => {
   });
 
   // TODO: don't know how to generate invalid token
-  test("TODO: should fail when user has invalid authentication", async () => {
+  test.todo(
+    "should fail when user has invalid authentication"
+    // , async () => {
     //const res = await request(server.app).post(
     //  `/${FAVORITE_CHARACTER_THREAD_ID}/hide`
     //);
     //expect(res.status).toBe(401);
     //expect(res.body).toEqual<GenericResponse>(ENSURE_LOGGED_IN_NO_TOKEN);
-  });
+    // }
+  );
 
   // TODO: permissions don't exist yet
-  test("TODO: should fail when user is not authorized to access thread", async () => {
+  test.todo(
+    "should fail when user is not authorized to access thread"
+    // , async () => {
     //const res = await request(server.app).post(
     //  `/${FAVORITE_CHARACTER_THREAD_ID}/hide`
     //);
     //expect(res.status).toBe(403);
     //expect(res.body).toEqual<GenericResponse>(ENSURE_THREAD_ACCESS_UNAUTHORIZED);
-  });
+    // }
+  );
 
   test("should fail when thread does not exist", async () => {
     setLoggedInUser(BOBATAN_USER_ID);
@@ -98,22 +104,28 @@ describe("Tests threads REST API - unhide", () => {
   });
 
   // TODO: don't know how to generate invalid token
-  test("TODO: should fail when user has invalid authentication", async () => {
+  test.todo(
+    "should fail when user has invalid authentication"
+    // , async () => {
     //const res = await request(server.app).delete(
     //  `/${FAVORITE_CHARACTER_THREAD_ID}/hide`
     //);
     //expect(res.status).toBe(401);
     //expect(res.body).toEqual<GenericResponse>(ENSURE_LOGGED_IN_NO_TOKEN);
-  });
+    // }
+  );
 
   // TODO: permissions don't exist yet
-  test("TODO: should fail when user is not authorized to access thread", async () => {
+  test.todo(
+    "should fail when user is not authorized to access thread"
+    // , async () => {
     //const res = await request(server.app).delete(
     //  `/${FAVORITE_CHARACTER_THREAD_ID}/hide`
     //);
     //expect(res.status).toBe(403);
     //expect(res.body).toEqual<GenericResponse>(ENSURE_THREAD_ACCESS_UNAUTHORIZED);
-  });
+    // }
+  );
 
   test("should fail when thread does not exist", async () => {
     setLoggedInUser(BOBATAN_USER_ID);


### PR DESCRIPTION
- Marks any tests that had empty or commented-out bodies as `test.todo` (only went by searching for `TODO`, so there are possibly others out there that should still be switched)
- Adds tests for removing category tags and content warning tags from posts

The `tags.test.ts` diff looks pretty dramatic bc I've pulled the "ci disable" block out (to see if it'll pass) and moved some loose test blocks inside the main "describe" block.

Some things got changed by running the formatter as I went, happy to revert any unwanted rearranging that may have happened.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203972941947518