### PR TITLE
Removing deprecated DbActivityThreadType

### DIFF
--- a/Types.ts
+++ b/Types.ts
@@ -95,41 +95,6 @@ export interface DbThreadType {
   starred: boolean;
 }
 
-// TODO[realms]: deprecate this
-export interface DbActivityThreadType {
-  post_id: string;
-  parent_post_id: null;
-  thread_id: string;
-  board_slug: string;
-  realm_id: string;
-  realm_slug: string;
-  author: number;
-  username: string;
-  user_avatar: string;
-  secret_identity_name: string;
-  secret_identity_avatar: string;
-  accessory_avatar?: string;
-  created: string;
-  content: string;
-  index_tags: string[];
-  whisper_tags: string[];
-  category_tags: string[];
-  content_warnings: string[];
-  muted: boolean;
-  hidden: boolean;
-  starred: boolean;
-  posts_amount: number;
-  threads_amount: number;
-  friend: boolean;
-  self: boolean;
-  new_posts_amount: number;
-  new_comments_amount: number;
-  is_new: boolean;
-  comments_amount: number;
-  thread_last_activity: string;
-  default_view: "thread" | "gallery" | "timeline";
-}
-
 export interface DbThreadSummaryType
   extends Omit<DbThreadType, "posts">,
     Omit<

--- a/server/feeds/sql/board-activity-by-external-id.sql
+++ b/server/feeds/sql/board-activity-by-external-id.sql
@@ -1,5 +1,3 @@
--- The return type of this query is DbActivityThreadType.
--- If updating, please also update DbActivityThreadType in Types.
 SELECT
     -- Thread details (DbThreadType)
     thread_external_id as thread_id,

--- a/server/feeds/sql/star-feed-activity.sql
+++ b/server/feeds/sql/star-feed-activity.sql
@@ -1,5 +1,3 @@
--- The return type of this query is DbActivityThreadType.
--- If updating, please also update DbActivityThreadType in Types.
 SELECT
     -- Thread details (DbThreadType)
     thread_external_id as thread_id,

--- a/server/feeds/sql/user-feed-activity.sql
+++ b/server/feeds/sql/user-feed-activity.sql
@@ -1,5 +1,3 @@
--- The return type of this query is DbActivityThreadType.
--- If updating, please also update DbActivityThreadType in Types.
 -- TODO: enforce this through tests
 SELECT
     -- Thread details (DbThreadType)

--- a/server/users/queries.ts
+++ b/server/users/queries.ts
@@ -2,7 +2,6 @@ import { SettingEntry, SettingValueTypes } from "../../types/settings";
 import { decodeCursor, encodeCursor } from "utils/queries-utils";
 import firebaseAuth, { auth } from "firebase-admin";
 
-import { DbActivityThreadType } from "Types";
 import debug from "debug";
 import { parseSettings } from "utils/settings";
 import pool from "server/db-pool";


### PR DESCRIPTION
remnants of deprecated `DbActivityThreadType` removed