### PR TITLE
Bringing realm roles and permissions up to date on a fresh branch

### DIFF
--- a/db/init/020_roles_and_permissions.sql
+++ b/db/init/020_roles_and_permissions.sql
@@ -19,7 +19,9 @@ CREATE TYPE role_permissions_type AS ENUM (
     'post_on_realm',
     'comment_on_realm',
     'create_thread_on_realm',
-    'access_locked_boards_on_realm'
+    'access_locked_boards_on_realm',
+    'view_roles_on_realm',
+    'view_roles_on_board'
 );
 
 CREATE TABLE IF NOT EXISTS roles
@@ -37,14 +39,18 @@ CREATE UNIQUE INDEX roles_string_id on roles(string_id);
 CREATE TABLE IF NOT EXISTS board_user_roles(
     user_id BIGINT REFERENCES users(id) ON DELETE RESTRICT NOT NULL,
     board_id BIGINT REFERENCES boards(id) ON DELETE RESTRICT NOT NULL,
-    role_id BIGINT REFERENCES roles(id) ON DELETE RESTRICT NOT NULL
+    role_id BIGINT REFERENCES roles(id) ON DELETE RESTRICT NOT NULL,
+    	/*This is a note admins may add to the role assignment for reference*/
+    label TEXT
 );
 CREATE UNIQUE INDEX board_user_roles_entry on board_user_roles(user_id, board_id, role_id);
 
 CREATE TABLE IF NOT EXISTS realm_user_roles(
     realm_id BIGINT REFERENCES realms(id) ON DELETE RESTRICT NOT NULL,
     user_id BIGINT REFERENCES users(id) ON DELETE RESTRICT NOT NULL,
-    role_id BIGINT REFERENCES roles(id) ON DELETE RESTRICT NOT NULL
+    role_id BIGINT REFERENCES roles(id) ON DELETE RESTRICT NOT NULL,
+    	/*This is a note admins may add to the role assignment for reference*/
+    label TEXT
 );
 CREATE UNIQUE INDEX realm_user_roles_entry on realm_user_roles(user_id, realm_id, role_id);
 

--- a/db/test_db_init/070_roles_insert.sql
+++ b/db/test_db_init/070_roles_insert.sql
@@ -16,37 +16,47 @@ VALUES
         ARRAY['edit_board_details'::role_permissions_type,
               'post_as_role'::role_permissions_type,
               'move_thread'::role_permissions_type,
-              'create_realm_invite'::role_permissions_type]);
+              'create_realm_invite'::role_permissions_type,
+							'view_roles_on_realm'::role_permissions_type,
+							'view_roles_on_board'::role_permissions_type]);
 
-INSERT INTO board_user_roles(user_id, board_id, role_id)
+INSERT INTO board_user_roles(user_id, board_id, role_id, label)
 VALUES
     ((SELECT id FROM users WHERE username = 'bobatan'),
      (SELECT id FROM boards WHERE slug = 'gore'),
-     (SELECT id FROM roles WHERE name = 'GoreMaster5000')),
+     (SELECT id FROM roles WHERE name = 'GoreMaster5000'),
+     'Test Label'),
     ((SELECT id FROM users WHERE username = 'bobatan'),
      (SELECT id FROM boards WHERE slug = 'memes'),
-     (SELECT id FROM roles WHERE name = 'The Memester'));
+     (SELECT id FROM roles WHERE name = 'The Memester'),
+     'Test Label');
 
-INSERT INTO realm_user_roles(realm_id, user_id, role_id)
+INSERT INTO realm_user_roles(realm_id, user_id, role_id, label)
 VALUES
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'),
      (SELECT id FROM users WHERE username = 'bobatan'), 
-     (SELECT id FROM roles WHERE name = 'The Owner')),
+     (SELECT id FROM roles WHERE name = 'The Owner'),
+     'Look ma, a label'),
     ((SELECT id FROM realms WHERE slug = 'uwu'),
      (SELECT id FROM users WHERE username = 'bobatan'), 
-     (SELECT id FROM roles WHERE name = 'The Memester')),
+     (SELECT id FROM roles WHERE name = 'The Memester'),
+     'meme machine'),
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'),
      (SELECT id FROM users WHERE username = 'bobatan'),
-     (SELECT id FROM roles WHERE name = 'GoreMaster5000')),
+     (SELECT id FROM roles WHERE name = 'GoreMaster5000'),
+     'we have fun here'),
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'),
      (SELECT id FROM users WHERE username = 'SexyDaddy69'), 
-     (SELECT id FROM roles WHERE name = 'The Owner')),
+     (SELECT id FROM roles WHERE name = 'The Owner'),
+     'well earned'),
     ((SELECT id FROM realms WHERE slug = 'uwu'),
      (SELECT id FROM users WHERE username = 'The Zodiac Killer'), 
-     (SELECT id FROM roles WHERE name = 'The Owner')),
+     (SELECT id FROM roles WHERE name = 'The Owner'),
+     'hello world'),
     ((SELECT id FROM realms WHERE slug = 'twisted-minds'),
      (SELECT id FROM users WHERE username = 'oncest5evah'), 
-     (SELECT id FROM roles WHERE name = 'GoreMaster5000'));
+     (SELECT id FROM roles WHERE name = 'GoreMaster5000'),
+     '');
 
 INSERT INTO content_warnings(warning)
 VALUES

--- a/server/boards/queries.ts
+++ b/server/boards/queries.ts
@@ -432,14 +432,8 @@ export const getBoardRoles = async ({
     }[]
   | null
 > => {
-  try {
-    const boardRoles = await pool.manyOrNone(sql.fetchRolesInBoard, {
-      board_external_id: boardExternalId,
-    });
-    return boardRoles;
-  } catch (e) {
-    error(`Error while fetching board roles.`);
-    error(e);
-    return null;
-  }
+  const boardRoles = await pool.manyOrNone(sql.fetchRolesInBoard, {
+    board_external_id: boardExternalId,
+  });
+  return boardRoles;
 };

--- a/server/boards/queries.ts
+++ b/server/boards/queries.ts
@@ -417,3 +417,29 @@ export const createThread = async ({
     return newThreadExternalId;
   });
 };
+
+export const getBoardRoles = async ({
+  boardExternalId,
+}: {
+  boardExternalId: string;
+}): Promise<
+  | {
+      user_id: string;
+			username:string
+			role_id: string;
+			role_name: string;
+      label: string | null;
+    }[]
+  | null
+> => {
+  try {
+    const boardRoles = await pool.manyOrNone(sql.fetchRolesInBoard, {
+      board_external_id: boardExternalId,
+    });
+    return boardRoles;
+  } catch (e) {
+    error(`Error while fetching board roles.`);
+    error(e);
+    return null;
+  }
+};

--- a/server/boards/routes.ts
+++ b/server/boards/routes.ts
@@ -762,20 +762,22 @@ router.get(
   ensureBoardAccess, ensureLoggedIn,
   ensureBoardPermission(BoardPermissions.viewRolesOnBoard),
   async (req, res) => {
+    try {
       const { board_id } = req.params;
       const boardRoles = await getBoardRoles({
         boardExternalId: board_id,
       });
-      if (!boardRoles){
-        throw new Internal500Error("failed to get board roles");
-      }
       if (!boardRoles?.length){
         res.status(200).json({roles:[]});
-        return;
+      return;
       }
       res.status(200).json({
         roles: boardRoles || [],
       });
+    } catch (e) {
+      error(e);
+      throw new Internal500Error("There was an error fetching board roles.");
+    }
   }
 );
 

--- a/server/boards/sql/index.ts
+++ b/server/boards/sql/index.ts
@@ -116,6 +116,22 @@ const updateBoardSettings = `
         settings = $/settings/
     WHERE boards.string_id = $/board_id/`;
 
+
+const fetchRolesInBoard = `
+    SELECT
+        users.firebase_id as user_firebase_id,
+        users.username as username,
+        roles.string_id as role_string_id,
+        roles.name as role_name,
+        board_user_roles.label as label
+    FROM board_user_roles
+    INNER JOIN boards ON board_user_roles.board_id = boards.id
+    INNER JOIN roles ON board_user_roles.role_id=roles.id
+    INNER JOIN users ON users.id=board_user_roles.user_id
+    WHERE boards.string_id = $/board_external_id/`;
+
+
+
 export default {
   getAllBoards: new QueryFile(path.join(__dirname, "all-boards.sql")),
   getBoardByExternalId: new QueryFile(
@@ -133,4 +149,5 @@ export default {
   pinBoardByExternalId,
   unpinBoardByExternalId,
   dismissNotificationsByExternalId,
+  fetchRolesInBoard,
 };

--- a/server/boards/sql/types.ts
+++ b/server/boards/sql/types.ts
@@ -16,6 +16,8 @@ export const BoardPermissionsEnumSchema = z.enum([
   "comment_on_realm",
   "create_thread_on_realm",
   "access_locked_boards_on_realm",
+  "view_roles_on_realm",
+	"view_roles_on_board",
 ]);
 export const BoardRestrictionsEnumSchema = z.enum(["lock_access", "delist"]);
 export type BoardRestrictionsEnum = z.infer<typeof BoardRestrictionsEnumSchema>;

--- a/server/boards/tests/by-external-id.test.ts
+++ b/server/boards/tests/by-external-id.test.ts
@@ -87,6 +87,8 @@ const GORE_BOARD_LOGGED_IN: BoardByExternalId = {
     "edit_content_notices",
     "move_thread",
     "create_realm_invite",
+    "view_roles_on_realm",
+    "view_roles_on_board",
   ],
   pinned_order: 1,
   posting_identities: [

--- a/server/boards/tests/routes/board-roles.test.ts
+++ b/server/boards/tests/routes/board-roles.test.ts
@@ -1,0 +1,48 @@
+import {
+    BOBATAN_USER_ID,
+    JERSEY_DEVIL_USER_ID,
+} from "test/data/auth";
+import { setLoggedInUser, startTestServer } from "utils/test-utils";
+
+import {
+      GORE_BOARD_ID,
+} from "test/data/boards";
+import debug from "debug";
+import { mocked } from "ts-jest/utils";
+import request from "supertest";
+import router from "../../routes";
+import stringify from "fast-json-stable-stringify";
+
+const log = debug("bobaserver:board:routes");
+  jest.mock("handlers/auth");
+  
+  
+  describe("Tests board role queries", () => {
+    const server = startTestServer(router);
+  
+    test("fetches board roles with permissions", async () => {
+      setLoggedInUser(BOBATAN_USER_ID);
+      const res = await request(server.app).get(`/${GORE_BOARD_ID}/roles`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+          roles: [
+            {
+              user_firebase_id: 'c6HimTlg2RhVH3fC1psXZORdLcx2',
+              username: 'bobatan',
+              role_string_id: "e5f86f53-6dcd-4f15-b6ea-6ca1f088e62d",
+              role_name: 'GoreMaster5000',
+              label: 'Test Label'
+            }
+          ]
+        });
+    });
+  
+    test("does not fetch board roles without permissions", async () => {
+      setLoggedInUser(JERSEY_DEVIL_USER_ID);
+      const res = await request(server.app).get(`/${GORE_BOARD_ID}/roles`);
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({
+        message: 'User does not have required permissions for board operation.'
+      });
+    });
+  });

--- a/server/realms/queries.ts
+++ b/server/realms/queries.ts
@@ -424,14 +424,8 @@ export const getRealmRoles = async ({
     }[]
   | null
 > => {
-  try {
-    const realmRoles = await pool.manyOrNone(sql.fetchRolesInRealm, {
-      realm_external_id: realmExternalId,
-    });
-    return realmRoles;
-  } catch (e) {
-    error(`Error while fetching realm roles.`);
-    error(e);
-    return null;
-  }
+  const realmRoles = await pool.manyOrNone(sql.fetchRolesInRealm, {
+    realm_external_id: realmExternalId,
+  });
+  return realmRoles;
 };

--- a/server/realms/queries.ts
+++ b/server/realms/queries.ts
@@ -409,3 +409,29 @@ export const checkUserOnRealm = async ({
     return null;
   }
 };
+
+export const getRealmRoles = async ({
+  realmExternalId,
+}: {
+  realmExternalId: string;
+}): Promise<
+  | {
+      user_id: string;
+			username:string
+			role_id: string;
+			role_name: string;
+      label: string | null;
+    }[]
+  | null
+> => {
+  try {
+    const realmRoles = await pool.manyOrNone(sql.fetchRolesInRealm, {
+      realm_external_id: realmExternalId,
+    });
+    return realmRoles;
+  } catch (e) {
+    error(`Error while fetching realm roles.`);
+    error(e);
+    return null;
+  }
+};

--- a/server/realms/routes.ts
+++ b/server/realms/routes.ts
@@ -910,24 +910,21 @@ router.get(
   ensureRealmExists, ensureLoggedIn,
   ensureRealmPermission(RealmPermissions.viewRolesOnRealm),
   async (req, res) => {
-    try {
-      const { realm_id } = req.params;
-      const realmRoles = await getRealmRoles({
-        realmExternalId: realm_id,
-      });
-      if (!realmRoles?.length){
-        res.status(200).json({roles:[]});
-        return;
-      }
-      res.status(200).json({
-        roles: realmRoles || [],
-      });
-    } catch (e) {
-      error(e);
-      res.status(500).json({
-        message: "There was an error fetching realm roles.",
-      });
+    const { realm_id } = req.params;
+    const realmRoles = await getRealmRoles({
+      realmExternalId: realm_id,
+    });
+    if (!realmRoles){
+      throw new Internal500Error("failed to get realm roles");
+    }
+    if (!realmRoles?.length){
+      res.status(200).json({roles:[]});
+      return;
+    }
+    res.status(200).json({
+      roles: realmRoles || [],
+    });
   }
-});
+);
 
 export default router;

--- a/server/realms/routes.ts
+++ b/server/realms/routes.ts
@@ -910,20 +910,22 @@ router.get(
   ensureRealmExists, ensureLoggedIn,
   ensureRealmPermission(RealmPermissions.viewRolesOnRealm),
   async (req, res) => {
-    const { realm_id } = req.params;
-    const realmRoles = await getRealmRoles({
-      realmExternalId: realm_id,
-    });
-    if (!realmRoles){
-      throw new Internal500Error("failed to get realm roles");
+    try {
+      const { realm_id } = req.params;
+      const realmRoles = await getRealmRoles({
+        realmExternalId: realm_id,
+      });
+      if (!realmRoles?.length){
+        res.status(200).json({roles:[]});
+        return;
+      }
+      res.status(200).json({
+        roles: realmRoles || [],
+      });
+    } catch (e) {
+      error(e);
+      throw new Internal500Error("There was an error fetching realm roles.");
     }
-    if (!realmRoles?.length){
-      res.status(200).json({roles:[]});
-      return;
-    }
-    res.status(200).json({
-      roles: realmRoles || [],
-    });
   }
 );
 

--- a/server/realms/sql/index.ts
+++ b/server/realms/sql/index.ts
@@ -71,6 +71,19 @@ JOIN users ON realm_users.user_id = users.id
 WHERE users.firebase_id = $/firebase_id/ AND realms.string_id = $/realm_external_id/
 `;
 
+const fetchRolesInRealm = `
+  SELECT
+    users.firebase_id as user_firebase_id,
+    users.username as username,
+    roles.string_id as role_string_id,
+    roles.name as role_name,
+    realm_user_roles.label as label
+  FROM realm_user_roles
+  INNER JOIN realms ON realm_user_roles.realm_id = realms.id
+  INNER JOIN roles ON realm_user_roles.role_id=roles.id
+  INNER JOIN users ON users.id=realm_user_roles.user_id
+  WHERE realms.string_id = $/realm_external_id/`;
+
 export default {
   getRealmBySlug: new QueryFile(path.join(__dirname, "realm-by-slug.sql")),
   dismissNotifications,
@@ -81,4 +94,5 @@ export default {
   getInvites,
   addUserToRealm,
   findUserOnRealm,
+  fetchRolesInRealm,
 };

--- a/server/realms/tests/realm-roles.test.ts
+++ b/server/realms/tests/realm-roles.test.ts
@@ -1,0 +1,64 @@
+import {
+    TWISTED_MINDS_REALM_EXTERNAL_ID,
+    UWU_REALM_EXTERNAL_ID
+} from "test/data/realms";
+import { setLoggedInUser, startTestServer } from "utils/test-utils";
+
+import {
+    BOBATAN_USER_ID,
+} from "test/data/auth";
+import request from "supertest";
+import router from "../routes";
+
+jest.mock("handlers/auth");
+  
+  describe("Tests realm role queries", () => {
+    const server = startTestServer(router);
+  
+    test("fetches realm roles with permissions", async () => {
+      setLoggedInUser(BOBATAN_USER_ID);
+      const res = await request(server.app).get(`/${TWISTED_MINDS_REALM_EXTERNAL_ID}/roles`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        roles: [
+          {
+            user_firebase_id: 'c6HimTlg2RhVH3fC1psXZORdLcx2',
+            username: 'bobatan',
+            role_string_id: '3df1d417-c36a-43dd-aaba-9590316ffc32',
+            role_name: 'The Owner',
+            label: 'Look ma, a label'
+          },
+          {
+            user_firebase_id: 'c6HimTlg2RhVH3fC1psXZORdLcx2',
+            username: 'bobatan',
+            role_string_id: 'e5f86f53-6dcd-4f15-b6ea-6ca1f088e62d',
+            role_name: 'GoreMaster5000',
+            label: 'we have fun here'
+          },
+          {
+            user_firebase_id: 'fb4',
+            username: 'SexyDaddy69',
+            role_string_id: '3df1d417-c36a-43dd-aaba-9590316ffc32',
+            role_name: 'The Owner',
+            label: 'well earned'
+          },
+          {
+            user_firebase_id: 'fb3',
+            username: 'oncest5evah',
+            role_string_id: 'e5f86f53-6dcd-4f15-b6ea-6ca1f088e62d',
+            role_name: 'GoreMaster5000',
+            label: ''
+          }
+        ]
+      });
+    });
+  
+    test("does not fetch realm roles without permissions", async () => {
+      setLoggedInUser(BOBATAN_USER_ID);
+      const res = await request(server.app).get(`/${UWU_REALM_EXTERNAL_ID}/roles`);
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({
+        message: 'User does not have required permissions for realm operation.'
+      });
+    });
+  });

--- a/server/users/tests/queries.test.ts
+++ b/server/users/tests/queries.test.ts
@@ -46,7 +46,7 @@ describe("Tests user queries", () => {
         description: "A role for the owner.",
         name: "The Owner",
         permissions:
-          "{edit_board_details,post_as_role,move_thread,create_realm_invite}",
+          "{edit_board_details,post_as_role,move_thread,create_realm_invite,view_roles_on_realm,view_roles_on_board}",
         id: OWNER_ROLE_EXTERNAL_ID,
         board_ids: [],
         accessory_external_id: "9e593709-419f-4b2c-b7ee-88ed47884c3c",
@@ -101,7 +101,7 @@ describe("Tests user queries", () => {
         color: "pink",
         description: "A role for the owner.",
         permissions:
-          "{edit_board_details,post_as_role,move_thread,create_realm_invite}",
+          "{edit_board_details,post_as_role,move_thread,create_realm_invite,view_roles_on_realm,view_roles_on_board}",
         board_ids: [],
         accessory_external_id: CROWN_ACCESSORY_EXTERNAL_ID,
       },

--- a/test/data/auth.ts
+++ b/test/data/auth.ts
@@ -1,6 +1,6 @@
 // bobatan:
 // twisted-minds realm: member,
-//   The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite),
+//   The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite, view_roles_on_realm),
 //   GoreMaster5000 (edit_board_details, post_as_role, edit_category_tags, edit_content_notices)
 // uwu realm: member,
 //   The Memester (all)
@@ -21,13 +21,13 @@ export const ONCEST_USER_ID = "fb3";
 
 // SexyDaddy69:
 // twisted-minds realm: member,
-//   The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite)
+//   The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite, view_roles_on_realm)
 // uwu realm: member
 export const SEXY_DADDY_USER_ID = "fb4";
 
 // The Zodiac Killer:
 // twisted-minds realm:
-// uwu realm: member, The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite)
+// uwu realm: member, The Owner (edit_board_details, post_as_role, move_thread, create_realm_invite, view_roles_on_realm)
 export const ZODIAC_KILLER_USER_ID = "fb5";
 
 export const GORE_MASTER_IDENTITY_ID = "e5f86f53-6dcd-4f15-b6ea-6ca1f088e62d";

--- a/test/data/boards.ts
+++ b/test/data/boards.ts
@@ -95,7 +95,7 @@ const GORE_WITH_ROLE_METADATA: LoggedInBoardMetadata = {
     },
   ],
   permissions: {
-    board_permissions: ["edit_board_details"],
+    board_permissions: ["edit_board_details", "view_roles_on_board"],
     post_permissions: ["edit_category_tags", "edit_content_notices"],
     thread_permissions: ["move_thread"],
   },

--- a/test/data/user.ts
+++ b/test/data/user.ts
@@ -45,6 +45,7 @@ export const ONCEST_USER_IDENTITY = {
 
 export const BOBATAN_TWISTED_MINDS_REALM_PERMISSIONS = [
   RealmPermissions.createRealmInvite,
+  RealmPermissions.viewRolesOnRealm,
   ...REALM_MEMBER_PERMISSIONS,
 ];
 

--- a/types/open-api/generated/types.ts
+++ b/types/open-api/generated/types.ts
@@ -34,6 +34,8 @@ export type ThreadActivitySummary = z.infer<
 export type ThreadSummary = z.infer<typeof schemas.ThreadSummarySchema>;
 export type Thread = z.infer<typeof schemas.ThreadSchema>;
 export type BoardDescription = z.infer<typeof schemas.BoardDescriptionSchema>;
+export type RealmRoles = z.infer<typeof schemas.RealmRolesSchema>;
+export type genericResponse = z.infer<typeof schemas.genericResponseSchema>;
 export type Cursor = z.infer<typeof schemas.CursorSchema>;
 export type FeedActivity = z.infer<typeof schemas.FeedActivitySchema>;
 export type IdentityParams = z.infer<typeof schemas.IdentityParamsSchema>;
@@ -65,7 +67,6 @@ export type NotificationsResponse = z.infer<
   typeof schemas.NotificationsResponseSchema
 >;
 export type InviteWithDetails = z.infer<typeof schemas.InviteWithDetailsSchema>;
-export type genericResponse = z.infer<typeof schemas.genericResponseSchema>;
 export type createInviteByRealmId_Body = z.infer<
   typeof schemas.createInviteByRealmId_BodySchema
 >;
@@ -119,11 +120,17 @@ export type pinBoardsByExternalIdResponse = z.infer<
 export type unpinBoardsByExternalIdResponse = z.infer<
   typeof schemas.endpoints.unpinBoardsByExternalId.response
 >;
+export type getBoardRolesByExternalIdResponse = z.infer<
+  typeof schemas.endpoints.getBoardRolesByExternalId.response
+>;
 export type visitBoardsByExternalIdResponse = z.infer<
   typeof schemas.endpoints.visitBoardsByExternalId.response
 >;
 export type getBoardsFeedByExternalIdResponse = z.infer<
   typeof schemas.endpoints.getBoardsFeedByExternalId.response
+>;
+export type getRealmActivityResponse = z.infer<
+  typeof schemas.endpoints.getRealmActivity.response
 >;
 export type getPersonalFeedResponse = z.infer<
   typeof schemas.endpoints.getPersonalFeed.response
@@ -160,6 +167,9 @@ export type getCurrentUserNotificationsResponse = z.infer<
 >;
 export type dismissUserNotificationsResponse = z.infer<
   typeof schemas.endpoints.dismissUserNotifications.response
+>;
+export type getRealmsRolesByExternalIdResponse = z.infer<
+  typeof schemas.endpoints.getRealmsRolesByExternalId.response
 >;
 export type getRealmsBySlugResponse = z.infer<
   typeof schemas.endpoints.getRealmsBySlug.response

--- a/types/open-api/permissions.yaml
+++ b/types/open-api/permissions.yaml
@@ -17,7 +17,11 @@ components:
       type: array
       items:
         type: string
-        enum: [edit_board_details]
+        enum: 
+          [
+            edit_board_details,
+            view_roles_on_board,
+          ]
     PostPermissions:
       type: array
       items:
@@ -46,4 +50,5 @@ components:
             comment_on_realm,
             create_thread_on_realm,
             access_locked_boards_on_realm,
+            view_roles_on_realm,
           ]

--- a/types/open-api/realm.yaml
+++ b/types/open-api/realm.yaml
@@ -84,3 +84,33 @@ components:
                     type: string
                     format: uuid
               - $ref: "#/components/schemas/BoardActivitySummary"
+    RealmRoles:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            type: object
+            properties:
+              user_id:
+                type: string
+                format: uuid
+              username:
+                description: Username.
+                type: string
+              role_string_id:
+                description: String id of role.
+                type: string
+                format: uuid
+              role_name:
+                description: Name of role.
+                type: string
+              label:
+                description: Label associated with role assignment
+                type: string
+            required:
+              - user_firebase_id
+              - username
+              - role_string_id
+              - role_name
+              - label

--- a/types/permissions.ts
+++ b/types/permissions.ts
@@ -22,6 +22,8 @@ export enum DbRolePermissions {
   comment_on_realm = "comment_on_realm",
   create_thread_on_realm = "create_thread_on_realm",
   access_locked_boards_on_realm = "access_locked_boards_on_realm",
+  view_roles_on_realm = "view_roles_on_realm",
+	view_roles_on_board = "view_roles_on_board",
 }
 
 export interface UserBoardPermissions {
@@ -37,6 +39,7 @@ export enum ThreadPermissions {
 
 export enum BoardPermissions {
   editMetadata = DbRolePermissions["edit_board_details"],
+  viewRolesOnBoard = DbRolePermissions["view_roles_on_board"],
 }
 
 export enum RealmPermissions {
@@ -47,6 +50,7 @@ export enum RealmPermissions {
   accessLockedBoardsOnRealm = DbRolePermissions[
     "access_locked_boards_on_realm"
   ],
+  viewRolesOnRealm = DbRolePermissions["view_roles_on_realm"],
 }
 
 export enum PostPermissions {


### PR DESCRIPTION
Moving over changes from [PR 126](https://github.com/BobaBoard/boba-backend/pull/126) to allow admin/owner role to view realm and board roles. Addresses most of BobaBoard/issues/issues/133 

Also updates relevant Zod types.