### PR TITLE
Fix ESM compatibility issues in dev server and redoc import

### DIFF
--- a/handlers/open-api.ts
+++ b/handlers/open-api.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { type Express } from "express";
-import * as redocExpressMiddleware from "redoc-express";
+import redocExpressMiddleware from "redoc-express";
 import swaggerJsdoc from "swagger-jsdoc";
 
 const info = debug("bobaserver:handlers:open-api-log");

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "open-api:generate": "tsx -r dotenv/config -r tsconfig-paths/register utils/generate-open-api-spec.ts dotenv_config_path=./.env.prod",
     "open-api:validate": "yarn run open-api:generate && validate-api open-api/open-api-spec.json && openapi-examples-validator open-api/open-api-spec.json --ignore-formats color quill-delta && openapi lint open-api/open-api-spec.json --skip-rule=no-ambiguous-paths",
     "server:build": "rm -rf ./dist && tsc && tsc-alias && copyfiles .env.prod firebase-sdk.json server/**/*.sql ./dist",
-    "server:dev": "cross-env DEBUG=bobaserver:*,-*info DEBUG_DEPTH=10 nodemon --watch . --exec node -r tsconfig-paths/register -r ts-node/register server/index.ts -e yaml,ts,sql",
+    "server:dev": "cross-env DEBUG=bobaserver:*,-*info DEBUG_DEPTH=10 nodemon --watch . --exec \"tsx -r dotenv/config server/index.ts\" -e yaml,ts,sql",
     "server:start": "cross-env DEBUG=bobaserver:*,-*info node -r dotenv/config dist/server/index.js dotenv_config_path=./.env.prod",
     "start": "yarn run server:start",
     "start-db": "node -e \"console.error('This command has been deprecated. Use db:start now.')\"",


### PR DESCRIPTION
The ESM migration in #224 missed updating the server:dev script, which still used ts-node/register. This fails because ts-node doesn't support ES modules without additional configuration.

- Switch server:dev from ts-node to tsx (already used elsewhere)
- Preload the .env before running nodemon
- Fix redoc-express import to use default import syntax